### PR TITLE
Fix typo for unsupported ruby version in 4.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,7 +9,7 @@
 
 * Adding cane metrics (Sathish, pull request #49)
   * Not yet included in hotspots
-  * *Removed ruby 1.9 support*
+  * *Removed ruby 1.8 support*
 
 ### MetricFu 3.0.1 / 2013-03-01
 


### PR DESCRIPTION
The readme states that 1.8 support was dropped due to cane, but the history file says you dropped 1.9 support. I presume the readme has the correct information.
