### PR TITLE
Close #56.

### DIFF
--- a/lib/metric_fu/initial_requires.rb
+++ b/lib/metric_fu/initial_requires.rb
@@ -2,7 +2,12 @@ require 'rake'
 require 'yaml'
 begin
   require 'psych'
+  # Don't complain that "syck has been removed" in Ruby 2.0. Using syck will
+  # complain, but then sets itself to psych anyway.
+  stderr = $stderr 
+  $stderr = File.open('/dev/null', 'w')
   YAML::ENGINE.yamler = 'syck'
+  $stderr = stderr
 rescue LoadError
   #nothing to report
 end


### PR DESCRIPTION
- Use psych instead of syck with Ruby 2.0 series without changing the
  actual method call.
- Fix "syck has been removed" error reported to users by sending the
  error to /dev/null.
