### PR TITLE
Update source line in Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'rake'
 group :development, :test do


### PR DESCRIPTION
Fix the following bundler deprecation warning:

> The source :rubygems is deprecated because HTTP requests are
> insecure. Please change your source to 'https://rubygems.org' if
> possible, or 'http://rubygems.org' if not.
