### PR TITLE
Allows setting of the --continue flag with flog

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 ### Master
 
+* Features
+  * Allow setting of the --continue flag with flog (Eric Wollesen)
+
 * Misc
   * Make Location and AnalyzedProblems code more confident (Avdi Grimm)
 

--- a/lib/metric_fu/metrics/flog/flog.rb
+++ b/lib/metric_fu/metrics/flog/flog.rb
@@ -25,9 +25,11 @@ module MetricFu
         dir_files = remove_excluded_files(dir_files)
         files += dir_files
       end
-      options = ::Flog.parse_options ["--all", "--details"]
-      # TODO determine if flogging should continue despite errors
-      # options = ::Flog.parse_options ["--all", "--details", "--continue"]
+      options = ::Flog.parse_options [
+        "--all",
+        "--details",
+        MetricFu.flog[:continue] ? "--continue" : nil,
+      ].compact
 
       @flogger = ::Flog.new options
       @flogger.flog files


### PR DESCRIPTION
This is useful because the version of ruby_parser in use by flog does
not support ruby 2.0's keyword arguments. Passing the --continue flag
allows metric_fu's flog to run to completion. Then saikuro barfs, but
hey, at least flog runs.

This can then be set in the .metrics file with:

```
MetricFu::Configuration.run do |config|
  config.flog = config.flog.merge({continue: true})
end
```
