### PR TITLE
Fix problem with missing rails best practice count.

### DIFF
--- a/lib/metric_fu/metrics/rails_best_practices/rails_best_practices_bluff_grapher.rb
+++ b/lib/metric_fu/metrics/rails_best_practices/rails_best_practices_bluff_grapher.rb
@@ -6,7 +6,7 @@ module MetricFu
     end
     def data
       [
-        ['rails_best_practices', @rails_best_practices.join(',')]
+        ['rails_best_practices', @rails_best_practices_count.join(',')]
       ]
     end
     def output_filename


### PR DESCRIPTION
Fixes issue introduced by 8781518 that resulted in error when running on rails project:

/Users/rcurry/proj/repos/metric_fu/lib/metric_fu/metrics/rails_best_practices/rails_best_practices_bluff_grapher.rb:9:in `data': undefined method`join' for nil:NilClass (NoMethodError)
