### PR TITLE
Dont set flay default minimum score.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,11 @@ As such, a _Feature_ would map to either major or minor. A _bug fix_ to a patch.
 
 ### Master
 
+* Features
+* Fixes
+* Misc
+  * Don't set a default flay minimum score (was 100); use flay default (16) instead. (Robin Curry #110)
+
 ### MetricFu 4.3.0 / 2013-07-26
 
 * Features

--- a/lib/metric_fu/metrics/flay/init.rb
+++ b/lib/metric_fu/metrics/flay/init.rb
@@ -4,7 +4,11 @@ MetricFu::Configuration.run do |config|
   config.add_graph(:flay)
   config.configure_metric(:flay,
                     { :dirs_to_flay => MetricFu.code_dirs, # was @code_dirs
-                    :minimum_score => 100,
-                    :filetypes => ['rb'] }
+                      # MetricFu has been setting the minimum score as 100 for
+                      # a long time. This is a really big number, considering
+                      # the default is 16. Commenting it out for documentation
+                      # of the setting, but to use the Flay default.
+                      # :minimum_score => 100,
+                      :filetypes => ['rb'] }
                           )
 end

--- a/spec/metric_fu/configuration_spec.rb
+++ b/spec/metric_fu/configuration_spec.rb
@@ -98,7 +98,7 @@ describe MetricFu::Configuration do
       it 'should set @flay to {:dirs_to_flay => @code_dirs}' do
         load_metric 'flay'
         @config.send(:flay).
-                should == {:dirs_to_flay => ['lib'], :filetypes=>["rb"], :minimum_score => 100}
+                should == {:dirs_to_flay => ['lib'], :filetypes=>["rb"]}
       end
 
       it 'should set @reek to {:dirs_to_reek => @code_dirs}' do


### PR DESCRIPTION
This is a proposal to consider not configuring **by default** a flay minimum score and instead allow flay to use its own default threshold (16). Currently we are setting it to 100, which seems pretty high and results in few if any hits, whereas when I run it with the flay default, it finds lots of useful information.

I realize that it is configurable and I could simply configure the minimum_score lower for myself and go on, but I think, coming to flay through metric_fu, most people are unlikely to do so or know what a reasonable threshold is without a deep dive into flay.
