### PR TITLE
Fix broken link to the Reek page.

### DIFF
--- a/lib/metric_fu/metrics/reek/template_awesome/reek.html.erb
+++ b/lib/metric_fu/metrics/reek/template_awesome/reek.html.erb
@@ -1,6 +1,6 @@
 <h3>Reek Results</h3>
 
-<p><a href="http://reek.rubyforge.org/">Reek</a> detects common code smells in ruby code.</p>
+<p><a href="http://github.com/troessner/reek">Reek</a> detects common code smells in ruby code.</p>
 
 <% graph_name = 'reek' %>
 <% if MetricFu.configuration.graph_engine == :gchart %>


### PR DESCRIPTION
The previous link redirects to a 404.
