### PR TITLE
Add debug-info command line option.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@ As such, a _Feature_ would map to either major or minor. A _bug fix_ to a patch.
   * Distinguish between an activated metric library and an enabled metric.
     * An enabled metric will be run.
     * An activated metric has had its library required.
+  * Add --debug-info command line switch to get debug info for Issues. (calveto)
 * Fixes
 * Misc
   * Moved environmental concerns into an Environment module ( Benjamin Fleischer / Robin Curry #91, #111)

--- a/lib/metric_fu/cli/parser.rb
+++ b/lib/metric_fu/cli/parser.rb
@@ -65,6 +65,7 @@ module MetricFu
             p.on_tail("-h", "--help", "Show this message") {puts p ; exit}
             short = @used_short.include?("v") ? "-V" : "-v"
             p.on_tail(short, "--version", "Print version") {puts @version ; exit} unless @version.nil?
+            p.on_tail("--debug-info", "Print debug info") { debug_info; exit }
             @default_values = @result.clone # save default values to reset @result in subsequent calls
           end
 
@@ -76,6 +77,16 @@ module MetricFu
 
           validate(@result) if self.respond_to?("validate")
           @result
+        end
+
+        def debug_info
+          puts "Ruby"
+          puts "  Version:  #{RUBY_VERSION}"
+          puts "  Platform: #{RUBY_PLATFORM}"
+          puts "  Engine:   #{RUBY_ENGINE}"
+          puts "\nMetricFu"
+          puts "  Version: #{@version}"
+          puts "\n  Dependencies #{`gem dependency metric_fu`}"
         end
 
         # Build a nicely formatted list of built-in


### PR DESCRIPTION
In reference to https://github.com/metricfu/metric_fu/issues/71
Allow user to get basic debug info, so they can paste it into a GitHub
issue.  Ruby(Version, engine, platform) MetricFu(Version, dependencies)
