### PR TITLE
[#119] Fix bug on windows where reek hung

### DIFF
--- a/spec/metric_fu/metrics/reek/reek_spec.rb
+++ b/spec/metric_fu/metrics/reek/reek_spec.rb
@@ -5,7 +5,9 @@ describe Reek do
     it "should include config parameters" do
       options = {:config_file_pattern => 'lib/config/*.reek', :dirs_to_reek => []}
       reek = MetricFu::Reek.new(options)
-      reek.should_receive(:`).with(/--config lib\/config\/\*\.reek/).and_return("")
+      files_to_analyze = ['lib/foo.rb','lib/bar.rb']
+      reek.stub(:files_to_analyze).and_return(files_to_analyze)
+      reek.should_receive(:`).with(/--config lib\/config\/\*\.reek lib\/foo.rb lib\/bar.rb/).and_return("")
       reek.emit
     end
   end


### PR DESCRIPTION
Fix #119
- Don't specify files separater as '/' as that's not necessarily true
- Skip reek if no files are found to prevent hanging because reek tries to reek from stdin when no options passed in.
