### PR TITLE
Update rails_best_practices.rb

### DIFF
--- a/lib/metric_fu/metrics/rails_best_practices/rails_best_practices.rb
+++ b/lib/metric_fu/metrics/rails_best_practices/rails_best_practices.rb
@@ -36,7 +36,7 @@ module MetricFu
 
         out[problem[:file]] ||= {}
 
-        lines = problem[:line].split(/\s*,\s*/)
+        lines = problem[:line].split(/\s*,\s*/) rescue []
         lines.each do |line|
           out[problem[:file]][line] ||= []
           out[problem[:file]][line] << {:type => :rails_best_practices, :description => problem[:problem]}


### PR DESCRIPTION
This is a fix for following error - 

/home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.3.1/lib/metric_fu/metrics/rails_best_practices/rails_best_practices.rb:48:in `block in per_file_info': undefined method`split' for nil:NilClass (NoMethodError)
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.3.1/lib/metric_fu/metrics/rails_best_practices/rails_best_practices.rb:41:in `each'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.3.1/lib/metric_fu/metrics/rails_best_practices/rails_best_practices.rb:41:in`per_file_info'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.3.1/lib/metric_fu/reporting/result.rb:48:in `add'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.3.1/lib/metric_fu/run.rb:23:in`block in measure'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.3.1/lib/metric_fu/run.rb:21:in `each'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.3.1/lib/metric_fu/run.rb:21:in`measure'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.3.1/lib/metric_fu/run.rb:10:in `run'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.3.1/lib/metric_fu/cli/helper.rb:11:in`run'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.3.1/lib/metric_fu/cli/client.rb:18:in `run'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.3.1/bin/metric_fu:9:in`<top (required)>'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/bin/metric_fu:19:in `load'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/bin/metric_fu:19:in`<main>'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/bin/ruby_noexec_wrapper:14:in `eval'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/bin/ruby_noexec_wrapper:14:in`<main>'

Error generated for following line --

"------------------"
{:file=>"app/models/building/processing_request.rb", :line=>nil, :problem=>"check 'save' return value or use 'save!'"}
"------------------"
