### PR TITLE
Fix for the NaN error

### DIFF
--- a/lib/metric_fu/metrics/rcov/rcov.rb
+++ b/lib/metric_fu/metrics/rcov/rcov.rb
@@ -131,7 +131,7 @@ module MetricFu
         lines = content[:lines]
         @global_total_lines_run += lines_run = lines.find_all {|line| line[:was_run] == true }.length
         @global_total_lines += total_lines = lines.length
-        percent_run = ((lines_run.to_f / total_lines.to_f) * 100).round
+        percent_run = ((lines_run.to_f / total_lines.to_f) * 100).round rescue 0
         files[fname][:percent_run] = percent_run
       end
     end


### PR DESCRIPTION
Wheh lines_run and total_lines are zero it gives NaN error. 

This happens for an empty file in config/initializers
