### PR TITLE
fix RcovHotspot map bug & update rcov config docs

### DIFF
--- a/.metrics
+++ b/.metrics
@@ -15,6 +15,7 @@ $metric_file_loaded = true
 #     rcov.enabled = true
 #     coverage_file = File.expand_path("coverage/rcov/rcov.txt", Dir.pwd)
 #     rcov.external = coverage_file
+#     rcov.activate
 #   end
 #
 #   config.configure_metric(:cane) do |cane|

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,1 +1,2 @@
 George Erickson
+Carlos Fernandez

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,8 @@ As such, a _Feature_ would map to either major or minor. A _bug fix_ to a patch.
 
 * Features
 * Fixes
+  * Update rcov config instructions in README to include call to activate (Carlos Fernandez, #145)
+  * rcov hotspot analyzer (MetricFu::RcovHotspot) now overrides map_strategy instead of map (Carlos Fernandez, #145)
 * Misc
   * Update to rails_best_practices that removes activesupport dependency (for inflecto). (Benjamin Fleischer, #134)
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ in your .metrics file add the below to run pre-generated metrics
         rcov.enabled = true
         coverage_file = File.expand_path("coverage/rcov/rcov.txt", Dir.pwd)
         rcov.external = coverage_file
+        rcov.activate
       end
     end
 

--- a/lib/metric_fu/metrics/rcov/rcov_hotspot.rb
+++ b/lib/metric_fu/metrics/rcov/rcov_hotspot.rb
@@ -10,7 +10,7 @@ class MetricFu::RcovHotspot < MetricFu::Hotspot
     :rcov
   end
 
-  def map(row)
+  def map_strategy
     :percentage_uncovered
   end
 

--- a/spec/metric_fu/metrics/rcov/rcov_hotspot_spec.rb
+++ b/spec/metric_fu/metrics/rcov/rcov_hotspot_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+require "metric_fu/metrics/hotspots/analysis/record"
+
+describe MetricFu::RcovHotspot do
+  describe "map" do
+    let(:zero_row) do
+      MetricFu::Record.new({"percentage_uncovered"=>0.0}, nil)
+    end
+
+    let(:non_zero_row) do
+      MetricFu::Record.new({"percentage_uncovered"=>0.75}, nil)
+    end
+
+    it {subject.map(zero_row).should eql(0.0)}
+    it {subject.map(non_zero_row).should eql(0.75)}
+  end
+end


### PR DESCRIPTION
i was having a heck of time getting simple-cov (using the rcov formatter) integrated with metric_fu.  i tracked down two issues:
- the config instructions in the readme file were missing a step
- the rcov hotspot analyzer had a bug related to mapping the results

I added a spec for the MetricFu::RcovHotspot class.  It includes two examples for map.

there are 4 failing examples in rcov_spec.  it appears that these are failing in master: https://travis-ci.org/metricfu/metric_fu/jobs/11822975.  i didn't try a fix because i think you have a few pull requests trying to fix this.

I ran this against 2.0.0-p247.  I will keep an eye on travis to see if it passes the other target runtimes.

Let me know if you want any additional changes.
