### PR TITLE
Fix for undefined method `+' for :percentage_uncovered:Symbol (NoMethodE...

### DIFF
--- a/lib/metric_fu/metrics/rcov/rcov_hotspot.rb
+++ b/lib/metric_fu/metrics/rcov/rcov_hotspot.rb
@@ -11,7 +11,7 @@ class MetricFu::RcovHotspot < MetricFu::Hotspot
   end
 
   def map(row)
-    :percentage_uncovered
+    row.public_send(:percentage_uncovered)
   end
 
   def reduce_strategy


### PR DESCRIPTION
...rror)

When I run rcov using following settings in .metrics file in my rails root it gives following error 

MetricFu::Configuration.run do |config|  
  config.configure_metric(:rcov) do |rcov|
    rcov.activate
    rcov.enabled = true
    rcov.external = File.expand_path("coverage/rcov/rcov.txt", Dir.pwd)
  end
end

/home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/analysis/scoring_strategies.rb:18:in `each': undefined method`+' for :percentage_uncovered:Symbol (NoMethodError)
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/analysis/scoring_strategies.rb:18:in `inject'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/analysis/scoring_strategies.rb:18:in`sum'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/analysis/scoring_strategies.rb:22:in `average'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/hotspot.rb:42:in`reduce'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/analysis/rankings.rb:61:in `block in calculate_metric_scores'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/analysis/rankings.rb:60:in`calculate_metric_scores'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/analysis/rankings.rb:41:in `calculate_score_for_granularity'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/analysis/rankings.rb:36:in`block in calculate_scores_by_granularities'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/analysis/rankings.rb:35:in `each'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/analysis/rankings.rb:35:in`calculate_scores_by_granularities'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/analysis/rankings.rb:13:in `block in calculate_scores'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/analysis/rankings.rb:12:in`each'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/analysis/rankings.rb:12:in `calculate_scores'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/hotspot_analyzer.rb:53:in`setup'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/hotspot_analyzer.rb:21:in `initialize'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/hotspots.rb:19:in`new'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/hotspots/hotspots.rb:19:in `analyze'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/generator.rb:100:in`block in generate_result'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/generator.rb:98:in `each'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/metrics/generator.rb:98:in`generate_result'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/reporting/result.rb:46:in `add'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/run.rb:21:in`block in measure'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/run.rb:19:in `each'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/run.rb:19:in`measure'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/run.rb:10:in `run'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/cli/helper.rb:11:in`run'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/lib/metric_fu/cli/client.rb:18:in `run'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/gems/metric_fu-4.4.3/bin/metric_fu:9:in`<top (required)>'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/bin/metric_fu:23:in `load'
    from /home/xpanxion/.rvm/gems/ruby-1.9.2-p320/bin/metric_fu:23:in`<main>'
