### PR TITLE
[Fix] Ensure external coverage file exists before running coverage metrics

### DIFF
--- a/.metrics
+++ b/.metrics
@@ -4,14 +4,13 @@
 #
 # MetricFu::Configuration.run do |config|
 #
-#   Configure Metrics
+#   # Configure Metrics
 #
-#   To configure individual metrics...
+#   # To configure individual metrics...
 #
 #   config.configure_metric(:rcov) do |rcov|
-#     rcov.enabled = true
-#     coverage_file = File.expand_path("coverage/rcov/rcov.txt", Dir.pwd)
-#     rcov.external = coverage_file
+#     rcov.coverage_file = MetricFu.run_path.join("coverage/rcov/rcov.txt")
+#     rcov.enable
 #     rcov.activate
 #   end
 #
@@ -29,7 +28,7 @@
 #     churn.start_date = '6 months ago'
 #   end
 #
-#   Or, to configure a group of metrics...
+#   # Or, to configure a group of metrics...
 #   config.configure_metrics.each do |metric|
 #     if [:churn, :flay, :flog].include?(metric.name)
 #       metric.enabled = true
@@ -39,31 +38,31 @@
 #   end
 #
 #
-#   Configure Formatters
+#   # Configure Formatters
 #
-#   By default, metric_fu will use the built-in html formatter
-#   to generate HTML reports for each metric with pretty graphs.
+#   # By default, metric_fu will use the built-in html formatter
+#   # to generate HTML reports for each metric with pretty graphs.
 
-#   To configure different formatter(s) or output ...
+#   # To configure different formatter(s) or output ...
 #
 #   config.configure_formatter(:html)
 #   config.configure_formatter(:yaml, "customreport.yml")
 #   config.configure_formatter(MyCustomFormatter)
 #
-#   MetricFu will attempt to require a custom formatter by
-#   fully qualified name based on ruby search path,
-#   but you may find that you need to add a require above.
+#   # MetricFu will attempt to require a custom formatter by
+#   # fully qualified name based on ruby search path,
+#   # but you may find that you need to add a require above.
 #
-#   For instance, to require a formatter in your app's lib directory, add the
-#   following line to the top of this file.
-#   require './lib/my_custom_formatter.rb'
+#   # For instance, to require a formatter in your app's lib directory, add the
+#   # following line to the top of this file.
+#   # require './lib/my_custom_formatter.rb'
 #
 #
-#   Configure Graph Engine
+#   # Configure Graph Engine
 #
-#   By default, metric_fu uses the bluff graph engine.
-#   To configure a different graph engine...
+#   # By default, metric_fu uses the bluff graph engine.
+#   # To configure a different graph engine...
 #
-#   config.configure_graph_engine(:gchart)
+#   # config.configure_graph_engine(:gchart)
 #
 # end

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ in your .metrics file add the below to run pre-generated metrics
 ```ruby
 MetricFu::Configuration.run do |config|
   config.configure_metric(:rcov) do |rcov|
-    rcov.enabled = true
-    rcov.external = File.expand_path("coverage/rcov/rcov.txt", Dir.pwd)
+    rcov.coverage_file = MetricFu.run_path.join("coverage/rcov/rcov.txt")
+    rcov.enable
     rcov.activate
   end
 end
@@ -164,13 +164,16 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
 SimpleCov.start
 ```
 
+Additionally, the `coverage_file` path must be specified as above
+and must exist.
+
 ## Compatibility
 
 * It is currently testing on MRI (>= 1.9.3), JRuby (19 mode), and Rubinius (19 mode). Ruby 1.8 is no longer supported.
 
 * For 1.8.7 support, see version 3.0.0 for partial support, or 2.1.3.7.18.1 (where [Semantic Versioning](http://semver.org/) goes to die)
 
-* MetricFu  no longer runs any of the analyzed code. For code coverage, You may still use rcov metrics as documented below
+* MetricFu  no longer runs any of the analyzed code. For code coverage, You may still use rcov metrics as documented above
 
 * The Cane, Flog, and Rails Best Practices metrics are disabled when Ripper is not available
 

--- a/lib/metric_fu/configuration.rb
+++ b/lib/metric_fu/configuration.rb
@@ -96,8 +96,12 @@ module MetricFu
       yield MetricFu.configuration
     end
 
-    def configure_metric(name)
+    def self.configure_metric(name)
       yield MetricFu::Metric.get_metric(name)
+    end
+
+    def configure_metric(name, &block)
+      self.class.configure_metric(name, &block)
     end
 
     def configure_metrics
@@ -105,20 +109,12 @@ module MetricFu
       MetricFu::Metric.metrics.each do |metric|
         if block_given?
           yield metric
-        elsif !metric_manually_configured?(metric)
+        else
           metric.enabled = false
           metric.enable
         end
         metric.activate if metric.enabled unless metric.activated
       end
-    end
-
-    # TODO: Remove this method.  If we run configure_metrics
-    #   and it disabled rcov, we shouldn't have to worry here
-    #   that rcov is a special case that can only be enabled
-    #   manually
-    def metric_manually_configured?(metric)
-      [:rcov].include?(metric.name)
     end
 
     # TODO: Reconsider method name/behavior, as it really adds a formatter

--- a/lib/metric_fu/loader.rb
+++ b/lib/metric_fu/loader.rb
@@ -81,6 +81,7 @@ module MetricFu
 
       Dir.glob(File.join(MetricFu.metrics_dir, '**/init.rb')).each{|init_file|require(init_file)}
 
+      MetricFu.configuration.configure_metrics
       load_user_configuration
 
       MetricFu.lib_require       { 'reporter' }

--- a/lib/metric_fu/metrics/rcov/init.rb
+++ b/lib/metric_fu/metrics/rcov/init.rb
@@ -6,11 +6,15 @@ module MetricFu
     end
 
     def default_run_options
-      { :environment => 'test',
-                    :test_files =>  Dir['{spec,test}/**/*_{spec,test}.rb'],
-                    :rcov_opts => rcov_opts,
-                    :external => nil
-                  }
+      {
+        :environment => 'test',
+        :test_files =>  Dir['{spec,test}/**/*_{spec,test}.rb'],
+        :rcov_opts => rcov_opts,
+      }
+    end
+
+    def coverage_file=(coverage_file)
+      configured_run_options.update(:external => coverage_file)
     end
 
     def has_graph?
@@ -18,11 +22,24 @@ module MetricFu
     end
 
     def enable
-      MetricFu.configuration.mf_debug("rcov is not available. See README")
+      if external_coverage_file?
+        super
+      else
+        mf_debug("RCov is not available. See README")
+      end
     end
 
     def activate
       super
+    end
+
+    def external_coverage_file?
+      if run_options.has_key?(:external)
+        File.exist?(file = run_options[:external].to_s) ||
+          mf_log("Configured RCov file #{file.inspect} does not exist")
+      else
+        false
+      end
     end
 
     private

--- a/lib/metric_fu/metrics/rcov/rcov.rb
+++ b/lib/metric_fu/metrics/rcov/rcov.rb
@@ -146,8 +146,9 @@ module MetricFu
       end
     end
 
+    # We never run rcov anymore
     def run_rcov?
-      !(options[:external])
+      false
     end
 
     def load_output
@@ -155,17 +156,13 @@ module MetricFu
     end
 
     def output_file
-      if run_rcov?
-        default_output_file
-      else
-        options.fetch(:external)
-      end
+      options.fetch(:external)
     end
 
+    # Only used if run_rcov? is true
     def default_output_file
-      File.join(metric_directory, 'rcov.txt')
+      output_file || File.join(metric_directory, 'rcov.txt')
     end
-
 
   end
 end

--- a/lib/metric_fu/run.rb
+++ b/lib/metric_fu/run.rb
@@ -1,4 +1,3 @@
-MetricFu.configure
 module MetricFu
   class Run
     def initialize
@@ -45,12 +44,10 @@ module MetricFu
       end
     end
     def configure_metric(metric, metric_options)
-      MetricFu::Configuration.run do |config|
-        config.configure_metric(metric) do |metric|
-          metric_options.each do |option, value|
-            mf_log "Setting #{metric} option #{option} to #{value}"
-            metric.public_send("#{option}=", value)
-          end
+      MetricFu::Configuration.configure_metric(metric) do |metric|
+        metric_options.each do |option, value|
+          mf_log "Setting #{metric} option #{option} to #{value}"
+          metric.public_send("#{option}=", value)
         end
       end
     end

--- a/spec/metric_fu/configuration_spec.rb
+++ b/spec/metric_fu/configuration_spec.rb
@@ -223,7 +223,7 @@ describe MetricFu::Configuration do
                               '--include-file "\Aapp,\Alib"',
                               "-Ispec"
                             ],
-                            :external => nil}
+                            }
         )
       end
 

--- a/spec/metric_fu/metrics/rcov/rcov_grapher_spec.rb
+++ b/spec/metric_fu/metrics/rcov/rcov_grapher_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+MetricFu.metrics_require { 'rcov/rcov_grapher' }
 
 describe RcovGrapher do
   before :each do


### PR DESCRIPTION
This also fixes #78 

RCov is enabled when a coverage file is specified `run_options[:external]` and exists
