### PR TITLE
[Fix] Set default Reek config to config/*.reek, per Reek docs

### DIFF
--- a/lib/metric_fu/metrics/reek/init.rb
+++ b/lib/metric_fu/metrics/reek/init.rb
@@ -7,7 +7,7 @@ module MetricFu
 
     def default_run_options
       { :dirs_to_reek => MetricFu::Io::FileSystem.directory('code_dirs'),
-                    :config_file_pattern => nil}
+                    :config_file_pattern => 'config/*.reek'}
     end
 
     def has_graph?


### PR DESCRIPTION
Setting to nil would make it use .reek in the project root
