### PR TITLE
Fix hotspot report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ test/version_tmp
 tmp
 *.swp
 tags
+.idea

--- a/lib/metric_fu/reporting/templates/awesome/awesome_template.rb
+++ b/lib/metric_fu/reporting/templates/awesome/awesome_template.rb
@@ -68,7 +68,7 @@ class AwesomeTemplate < MetricFu::Template
 
     per_file_data.each_pair do |file, lines|
       next if file.to_s.empty?
-      next unless File.exists?(file)
+      next unless File.file?(file)
 
       data = File.readlines(file)
       fn = "#{file.gsub(%r{/}, '_')}.html"


### PR DESCRIPTION
Use case:
Churn founds the path to my submodule as being changed too much.
When hotspot generates its report, it tries to "readline" the folder that contains the submodule detected by Churn and raises:

```
Is a directory - blah
/gems/metric_fu-1a2abb36a1fd/lib/metric_fu/reporting/templates/awesome/awesome_template.rb:73:in `readlines'
/gems/metric_fu-1a2abb36a1fd/lib/metric_fu/reporting/templates/awesome/awesome_template.rb:73:in `block in write_file_data'
/gems/metric_fu-1a2abb36a1fd/lib/metric_fu/reporting/templates/awesome/awesome_template.rb:69:in `each_pair'
/gems/metric_fu-1a2abb36a1fd/lib/metric_fu/reporting/templates/awesome/awesome_template.rb:69:in `write_file_data'
/gems/metric_fu-1a2abb36a1fd/lib/metric_fu/reporting/templates/awesome/awesome_template.rb:44:in `write'
/gems/metric_fu-1a2abb36a1fd/lib/metric_fu/formatter/html.rb:54:in `save_templatized_result'
/gems/metric_fu-1a2abb36a1fd/lib/metric_fu/formatter/html.rb:22:in `finish'
/gems/metric_fu-1a2abb36a1fd/lib/metric_fu/reporter.rb:33:in `block in notify'
/gems/metric_fu-1a2abb36a1fd/lib/metric_fu/reporter.rb:32:in `each'
/gems/metric_fu-1a2abb36a1fd/lib/metric_fu/reporter.rb:32:in `notify'
/gems/metric_fu-1a2abb36a1fd/lib/metric_fu/reporter.rb:12:in `finish'
/gems/metric_fu-1a2abb36a1fd/lib/metric_fu/run.rb:23:in `measure'
/gems/metric_fu-1a2abb36a1fd/lib/metric_fu/run.rb:9:in `run'
/gems/metric_fu-1a2abb36a1fd/lib/metric_fu.rb:73:in `run'
/gems/metric_fu-1a2abb36a1fd/lib/metric_fu.rb:89:in `run_only'
/gems/metric_fu-1a2abb36a1fd/lib/metric_fu/tasks/metric_fu.rake:17:in `block (2 levels) in <top (required)>'
/gems/rake-10.0.4/lib/rake/task.rb:246:in `call'
/gems/rake-10.0.4/lib/rake/task.rb:246:in `block in execute'
/gems/rake-10.0.4/lib/rake/task.rb:241:in `each'
/gems/rake-10.0.4/lib/rake/task.rb:241:in `execute'
/gems/rake-10.0.4/lib/rake/task.rb:184:in `block in invoke_with_call_chain'
/gems/rake-10.0.4/lib/rake/task.rb:177:in `invoke_with_call_chain'
/gems/rake-10.0.4/lib/rake/task.rb:170:in `invoke'
/gems/rake-10.0.4/lib/rake/application.rb:143:in `invoke_task'
/gems/rake-10.0.4/lib/rake/application.rb:101:in `block (2 levels) in top_level'
/gems/rake-10.0.4/lib/rake/application.rb:101:in `each'
/gems/rake-10.0.4/lib/rake/application.rb:101:in `block in top_level'
/gems/rake-10.0.4/lib/rake/application.rb:110:in `run_with_threads'
/gems/rake-10.0.4/lib/rake/application.rb:95:in `top_level'
/gems/rake-10.0.4/lib/rake/application.rb:73:in `block in run'
/gems/rake-10.0.4/lib/rake/application.rb:160:in `standard_exception_handling'
/gems/rake-10.0.4/lib/rake/application.rb:70:in `run'
/bin/ruby_noexec_wrapper:14:in `eval'
/bin/ruby_noexec_wrapper:14:in `<main>'
Tasks: TOP => metrics:only
(See full trace by running task with --trace)
```

This error did not occur with gem 4.4.4.

Here is my debug information:

```
$ metric_fu --debug-info
{"Ruby"=>
  {"Engine"=>"ruby",
   "Version"=>"2.0.0",
   "Patchlevel"=>247,
   "Ripper Support"=>true,
   "Rubygems Version"=>"2.0.3",
   "Long Description"=>
    "ruby 2.0.0p247 (2013-06-27 revision 41674) [x86_64-darwin12.4.0]"},
 "Environment"=>
  {"VERBOSE"=>"false",
   "External Encoding"=>"UTF-8",
   "Internal Encoding"=>"",
   "Host Architecture"=>"x86_64-apple-darwin12.4.0",
   "Ruby Prefix"=>"/Users/adrien/.rvm/rubies/ruby-2.0.0-p247",
   "Ruby Options"=>
    "RUBYOPT=-I/Users/adrien/.rvm/gems/ruby-2.0.0-p247@global/gems/bundler-1.3.5/lib -rbundler/setup"},
 "MetricFu"=>
  {"Version"=>"4.4.4",
   "Verbose Mode"=>false,
   "Enabled Metrics"=>
    [:cane,
     :churn,
     :flay,
     :flog,
     :stats,
     :saikuro,
     :reek,
     :roodi,
     :rails_best_practices,
     :hotspots],
   "Dependencies"=>
    [{"name"=>"flay", "version"=>[">= 2.0.1", "~> 2.1"]},
     {"name"=>"churn", "version"=>["~> 0.0.28"]},
     {"name"=>"flog", "version"=>[">= 4.1.1", "~> 4.1"]},
     {"name"=>"reek", "version"=>[">= 1.3.4", "~> 1.3"]},
     {"name"=>"cane", "version"=>[">= 2.5.2", "~> 2.5"]},
     {"name"=>"rails_best_practices", "version"=>[">= 1.14.3", "~> 1.14"]},
     {"name"=>"saikuro", "version"=>[">= 1.1.1.0"]},
     {"name"=>"roodi", "version"=>["~> 3.1"]},
     {"name"=>"code_metrics", "version"=>["~> 0.1"]},
     {"name"=>"redcard", "version"=>[">= 0"]},
     {"name"=>"coderay", "version"=>[">= 0"]},
     {"name"=>"multi_json", "version"=>[">= 0"]},
     {"name"=>"rcov", "version"=>["~> 0.8"]}]}}
```

I was not able to track down the root cause of the bug (the submodule was detected by churn as well) so I made this workaround (not this stupid anyway?).
