### PR TITLE
Add churn option (--ignore_files)

### DIFF
--- a/lib/metric_fu/metrics/churn/churn.rb
+++ b/lib/metric_fu/metrics/churn/churn.rb
@@ -47,7 +47,7 @@ module MetricFu
       opts = ["--yaml"]
       churn_options.each do |churn_option, command_flag|
         if has_option?(churn_option)
-          opts << %(#{command_flag}=#{options[churn_option]})
+          opts << "#{command_flag}=#{options[churn_option]}"
         end
       end
       opts.join(" ")
@@ -56,6 +56,7 @@ module MetricFu
     def has_option?(churn_option)
       options.include?(churn_option)
     end
+
     def churn_options
       {
         :minimum_churn_count => '--minimum_churn_count',

--- a/lib/metric_fu/metrics/churn/init.rb
+++ b/lib/metric_fu/metrics/churn/init.rb
@@ -6,7 +6,7 @@ module MetricFu
     end
 
     def default_run_options
-      { :start_date => %q("1 year ago"), :minimum_churn_count => 10}
+      { :start_date => %q("1 year ago"), :minimum_churn_count => 10, :ignore_files => "" }
     end
 
     def has_graph?

--- a/spec/metric_fu/metrics/churn/churn_spec.rb
+++ b/spec/metric_fu/metrics/churn/churn_spec.rb
@@ -22,7 +22,7 @@ describe MetricFu::ChurnGenerator do
 
     it "initializes with given minimum_churn_count option" do
       churn = MetricFu::ChurnGenerator.new( { :minimum_churn_count => 5 })
-      churn.send(:build_churn_options).should == '--yaml --minimum_churn_count="5"'
+      churn.send(:build_churn_options).should == '--yaml --minimum_churn_count=5'
     end
 
     it "initializes with given ignore option" do


### PR DESCRIPTION
Allow using --ignore_files option for churn

```
config.configure_metric(:churn) do |churn|
    churn.ignore_files = %q("Gemfile, Gemfile.lock, config/locales/fr.yml, config/locales/en.yml, db/schema.rb")
end
```
