### PR TITLE
Run MetricFu.configure only once

### DIFF
--- a/lib/metric_fu/run.rb
+++ b/lib/metric_fu/run.rb
@@ -1,4 +1,3 @@
-MetricFu.configure
 module MetricFu
   class Run
     def initialize


### PR DESCRIPTION
MetricFu.configure runs MetricFu::Configuration#configure_metrics without
a block. When run without a block, it causes the .metrics file to be
overridden. Removing the call prevents this behavior.
