### PR TITLE
Fixed crash, when reek reports '0 total warnings'.

### DIFF
--- a/lib/metric_fu/metrics/reek/reek.rb
+++ b/lib/metric_fu/metrics/reek/reek.rb
@@ -23,6 +23,7 @@ module MetricFu
     def analyze
       @matches = @output.chomp.split("\n\n").map{|m| m.split("\n") }
       @matches = @matches.map do |match|
+        break {} if zero_warnings?(match)
         file_path = match.shift.split(' -- ').first
         file_path = file_path.gsub('"', ' ').strip
         code_smells = match.map do |smell|
@@ -115,5 +116,8 @@ module MetricFu
       '-n'
     end
 
+    def zero_warnings?(match)
+      match.last == "0 total warnings"
+    end
   end
 end


### PR DESCRIPTION
```
gems/metric_fu-4.7.2/lib/metric_fu/metrics/reek/reek.rb:27:in `block in analyze': undefined method `gsub' for nil:NilClass (NoMethodError)
gems/metric_fu-4.7.2/lib/metric_fu/metrics/reek/reek.rb:25:in `map'
gems/metric_fu-4.7.2/lib/metric_fu/metrics/reek/reek.rb:25:in `analyze'
gems/metric_fu-4.7.2/lib/metric_fu/metrics/generator.rb:115:in `generate_result'
gems/metric_fu-4.7.2/lib/metric_fu/reporting/result.rb:50:in `add'
gems/metric_fu-4.7.2/lib/metric_fu/run.rb:20:in `block in measure'
gems/metric_fu-4.7.2/lib/metric_fu/run.rb:18:in `each'
gems/metric_fu-4.7.2/lib/metric_fu/run.rb:18:in `measure'
gems/metric_fu-4.7.2/lib/metric_fu/run.rb:9:in `run'
gems/metric_fu-4.7.2/lib/metric_fu/cli/helper.rb:18:in `run'
gems/metric_fu-4.7.2/lib/metric_fu/cli/client.rb:18:in `run'
gems/metric_fu-4.7.2/bin/metric_fu:9:in `<top (required)>'
bin/metric_fu:23:in `load'
bin/metric_fu:23:in `<main>'
bin/ruby_executable_hooks:15:in `eval'
bin/ruby_executable_hooks:15:in `<main>'
```

With 0 warnings the report is empty and the graph shows "No Data".
