### PR TITLE
Prevent roodi info lines to end up in the results

### DIFF
--- a/lib/metric_fu/metrics/roodi/roodi.rb
+++ b/lib/metric_fu/metrics/roodi/roodi.rb
@@ -17,7 +17,7 @@ module MetricFu
       @output = MetricFu::Utility.strip_escape_codes(@output)
       @matches = @output.chomp.split("\n").map{|m| m.split(" - ") }
       total = @matches.pop
-      @matches.reject! {|array| array.empty? }
+      @matches.reject! {|array| array.size < 2 }
       @matches.map! do |match|
         file, line = match[0].split(':')
         problem = match[1]

--- a/spec/metric_fu/metrics/roodi/roodi_spec.rb
+++ b/spec/metric_fu/metrics/roodi/roodi_spec.rb
@@ -18,4 +18,65 @@ describe MetricFu::RoodiGenerator do
       roodi.emit
     end
   end
+
+  describe "analyze" do
+    context "when it has multiple failures" do
+      before :each do
+        lines = <<-HERE
+
+Running Roodi checks
+./app/models/some_model.rb:14 - Found = in conditional.  It should probably be an ==
+lib/some_file.rb:53 - Rescue block should not be empty.
+
+Checked 65 files
+        HERE
+
+        roodi = MetricFu::RoodiGenerator.new
+        roodi.instance_variable_set(:@output, lines)
+        @matches = roodi.analyze
+      end
+
+      it "should find all problems" do
+        problem_count = @matches[:problems].size
+        expect(problem_count).to eq(2)
+      end
+
+      it "should find the file of the problem" do
+        problem = @matches[:problems].first
+        expect(problem[:file]).to eq("./app/models/some_model.rb")
+      end
+
+      it "should find the line of the problem" do
+        problem = @matches[:problems].first
+        expect(problem[:line]).to eq("14")
+      end
+
+      it "should find the description of the problem" do
+        problem = @matches[:problems].first
+        expect(problem[:problem]).to eq("Found = in conditional.  It should probably be an ==")
+      end
+    end
+  end
+
+  context "when it has no failures" do
+    before :each do
+      lines = <<-HERE
+
+Running Roodi checks
+
+Checked 42 files
+Found 0 errors.
+
+      HERE
+
+      roodi = MetricFu::RoodiGenerator.new
+      roodi.instance_variable_set(:@output, lines)
+      @matches = roodi.analyze
+    end
+
+    it "should have no problems" do
+      problem_count = @matches[:problems].size
+      expect(problem_count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
Roodi output like

```
Running Roodi checks
Checked 42 files
```

ended up in the metric results as problems, these are now filtered out.

Martin
