### PR TITLE
Use flay directly

### DIFF
--- a/lib/metric_fu/metric.rb
+++ b/lib/metric_fu/metric.rb
@@ -43,10 +43,11 @@ module MetricFu
       run_options.map { |k, v| "--#{k} #{v}" }.join(" ")
     end
 
-    def run
+    def run(options = run_options)
       not_implemented
     end
 
+    # TODO: move into generator
     def run_external(args = default_run_args)
       runner = GemRun.new(
         gem_name: gem_name.to_s,

--- a/lib/metric_fu/metrics/flay/generator.rb
+++ b/lib/metric_fu/metrics/flay/generator.rb
@@ -5,8 +5,7 @@ module MetricFu
     end
 
     def emit
-      args =  "#{minimum_duplication_mass} #{dirs_to_flay}"
-      @output = run!(args)
+      @output = run(options)
     end
 
     def analyze
@@ -35,17 +34,27 @@ module MetricFu
       }
     end
 
+    def run(options)
+      flay_options = Flay.default_options.merge(minimum_duplication_mass)
+      flay = Flay.new flay_options
+      files = Flay.expand_dirs_to_files(dirs_to_flay)
+      flay.process(*files)
+      MetricFu::Utility.capture_output do
+         flay.report
+      end
+    end
+
     private
 
     def minimum_duplication_mass
       flay_mass = options[:minimum_score]
-      return "" unless flay_mass
+      return {} unless flay_mass
 
-      "--mass #{flay_mass} "
+      { :mass => flay_mass }
     end
 
     def dirs_to_flay
-      options[:dirs_to_flay].join(" ")
+      options[:dirs_to_flay]
     end
   end
 end

--- a/lib/metric_fu/metrics/flay/metric.rb
+++ b/lib/metric_fu/metrics/flay/metric.rb
@@ -22,6 +22,7 @@ module MetricFu
     end
 
     def activate
+      activate_library 'flay'
       super
     end
   end

--- a/spec/metric_fu/metrics/flay/generator_spec.rb
+++ b/spec/metric_fu/metrics/flay/generator_spec.rb
@@ -8,7 +8,10 @@ describe MetricFu::FlayGenerator do
       allow(File).to receive(:directory?).and_return(true)
       @flay = MetricFu::FlayGenerator.new(options)
 
-      expect(@flay).to receive(:run!).with(" app lib")
+      expected_options = Flay.default_options
+      expect(Flay).to receive(:expand_dirs_to_files).with(options[:dirs_to_flay])
+      flay = double('flay', :process => nil)
+      allow(Flay).to receive(:new).and_return(flay)
       output = @flay.emit
     end
 
@@ -17,7 +20,9 @@ describe MetricFu::FlayGenerator do
       allow(File).to receive(:directory?).and_return(true)
       @flay = MetricFu::FlayGenerator.new(options)
 
-      expect(@flay).to receive(:run!).with("--mass 99  ")
+      expected_options = Flay.default_options.merge(:mass => 99)
+      flay = double('flay', :process => nil)
+      expect(Flay).to receive(:new).with(expected_options).and_return(flay)
       output = @flay.emit
     end
   end


### PR DESCRIPTION
Implemented per https://github.com/seattlerb/flay/blob/master/bin/flay

We still have to use `flay.report` as getting the information in it without calling it would basically require duplicating the code in it and replacing warn/puts with a data structure.  So, in the end, it is still `MetricFu::Utility.capture_output { flay.report }`

I suppose I could redefine `def flay.puts(msg)` and `def flay.warn(msg)`
i.e. [bin/flay](https://github.com/seattlerb/flay/blob/master/bin/flay)

``` ruby
require 'flay'

flay = Flay.new Flay.parse_options(ARGV)

files = Flay.expand_dirs_to_files(*ARGV)

flay.process(*files)
flay.report
```

[flay.report](https://github.com/seattlerb/flay/blob/master/lib/flay.rb)

``` ruby
  def flay.report prune = nil
    analyze

    puts "Total score (lower is better) = #{self.total}"

    if option[:summary] then
      puts

      self.summary.sort_by { |_,v| -v }.each do |file, score|
        puts "%8.2f: %s" % [score, file]
      end

      return
    end

    count = 0
    sorted = masses.sort_by { |h,m|
      [-m,
       hashes[h].first.file,
       hashes[h].first.line,
       hashes[h].first.first.to_s]
    }
    sorted.each do |hash, mass|
      nodes = hashes[hash]
      next unless nodes.first.first == prune if prune
      puts

      same = identical[hash]
      node = nodes.first
      n = nodes.size
      match, bonus = if same then
                       ["IDENTICAL", "*#{n}"]
                     else
                       ["Similar",   ""]
                     end

      if option[:number] then
        count += 1

        puts "%d) %s code found in %p (mass%s = %d)" %
         [count, match, node.first, bonus, mass]
      else
        puts "%s code found in %p (mass%s = %d)" %
         [match, node.first, bonus, mass]
      end

      nodes.sort_by { |x| [x.file, x.line] }.each_with_index do |x, i|
        if option[:diff] then
          c = (?A.ord + i).chr
          extra = " (FUZZY)" if x.modified?
          puts "  #{c}: #{x.file}:#{x.line}#{extra}"
        else
          extra = " (FUZZY)" if x.modified?
          puts "  #{x.file}:#{x.line}#{extra}"
        end
      end

      if option[:diff] then
        puts
        sources = nodes.map do |s|
          msg = "sexp_to_#{File.extname(s.file).sub(/./, '')}"
          self.respond_to?(msg) ? self.send(msg, s) : sexp_to_rb(s)
        end
        puts n_way_diff(*sources)
      end
    end
  end
```
