### PR TITLE
refactor MetricFu::Templates::MetricsTemplate#write into a composed method.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@ As such, a _Feature_ would map to either major (breaking change) or minor. A _bu
 * Features
 * Fixes
 * Misc
+  * Refactor MetricFu::Templates::MetricsTemplate#write into a composed method. (#237)
 
 ### [4.11.1](https://github.com/metricfu/metric_fu/compare/v4.11.0...v4.11.1)
 


### PR DESCRIPTION
Hi! Thanks for metric_fu!

When running metric_fu on itself, Roodi generates 9 errors. Most of these are related to code copy and pasted from elsewhere (like ActiveSupport's `#constantize` method). However, Roodi opines that `MetricFu::Templates::MetricsTemplate#write` is too long and complex, and I agree. Therefore, I have applied some extract method refactorings, and reduced it into a composed method. Roodi now has 8 errors!
