### PR TITLE
Use reek as library

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@ As such, a _Feature_ would map to either major (breaking change) or minor. A _bu
 * Breaking Changes
 * Features
 * Fixes
+  * Use reek as library, otherwise reek >= 1.6.2 hangs while reading input from stdin. (Martin Gotink, #240, fixes #239)
 * Misc
   * Refactor MetricFu::Templates::MetricsTemplate#write into a composed method. (#237)
 

--- a/lib/metric_fu/metrics/reek/generator.rb
+++ b/lib/metric_fu/metrics/reek/generator.rb
@@ -107,7 +107,7 @@ module MetricFu
         turn_off_color,
         config_option,
         *files
-      ]
+      ].reject(&:empty?)
     end
 
     # TODO: Check that specified line config file exists

--- a/lib/metric_fu/metrics/reek/generator.rb
+++ b/lib/metric_fu/metrics/reek/generator.rb
@@ -13,12 +13,19 @@ module MetricFu
         mf_log "Skipping Reek, no files found to analyze"
         @output = ""
       else
-        args =  cli_options(files)
+        args = cli_options(files)
         @output = run!(args)
         @output = massage_for_reek_12 if reek_12?
       end
     end
 
+    def run!(args)
+      require 'reek/cli/application'
+
+      MetricFu::Utility.capture_output do
+        Reek::Cli::Application.new(args).execute
+      end
+    end
 
     def analyze
       @matches = @output.chomp.split("\n\n").map{|m| m.split("\n") }
@@ -99,8 +106,8 @@ module MetricFu
         disable_line_number_option,
         turn_off_color,
         config_option,
-        files.join(' ')
-      ].join(' ')
+        *files
+      ]
     end
 
     # TODO: Check that specified line config file exists

--- a/spec/metric_fu/metrics/reek/generator_spec.rb
+++ b/spec/metric_fu/metrics/reek/generator_spec.rb
@@ -19,6 +19,13 @@ describe MetricFu::ReekGenerator do
       reek.emit
     end
 
+    it "doesn't add an empty parameter when no config file pattern is specified" do
+      expect(reek).to receive(:run!) do |args|
+        expect(args).not_to include('')
+      end.and_return('')
+      reek.emit
+    end
+
     it "turns off color output from reek output, for reek 1.3.7 or greater" do
       allow(reek).to receive(:reek_version).and_return('1.3.7')
       expect(reek).to receive(:run!) do |args|

--- a/spec/metric_fu/metrics/reek/generator_spec.rb
+++ b/spec/metric_fu/metrics/reek/generator_spec.rb
@@ -13,29 +13,39 @@ describe MetricFu::ReekGenerator do
 
     it "includes config file pattern into reek parameters when specified" do
       options.merge!({:config_file_pattern => 'lib/config/*.reek' })
-      expect(reek).to receive(:run!).with(/--config lib\/config\/\*\.reek /).and_return("")
+      expect(reek).to receive(:run!) do |args|
+        expect(args).to include('--config lib/config/*.reek')
+      end.and_return('')
       reek.emit
     end
 
     it "turns off color output from reek output, for reek 1.3.7 or greater" do
       allow(reek).to receive(:reek_version).and_return('1.3.7')
-      expect(reek).to receive(:run!).with(/(?=--no-color)/).and_return("")
+      expect(reek).to receive(:run!) do |args|
+        expect(args).to include('--no-color')
+      end.and_return("")
       reek.emit
     end
 
     it "does not set an (invalid) --no-color option for reek < 1.3.7" do
       allow(reek).to receive(:reek_version).and_return('1.3.6')
-      expect(reek).to receive(:run!).with(/(?!--no-color)/).and_return("")
+      expect(reek).to receive(:run!) do |args|
+        expect(args).not_to include('--no-color')
+      end.and_return("")
       reek.emit
     end
 
     it "disables lines numbers from reek output" do
-      expect(reek).to receive(:run!).with(/--no-line-numbers /).and_return("")
+      expect(reek).to receive(:run!) do |args|
+        expect(args).to include('--no-line-numbers')
+      end.and_return("")
       reek.emit
     end
 
     it "includes files to analyze into reek parameters" do
-      expect(reek).to receive(:run!).with(/lib\/foo.rb lib\/bar.rb$/).and_return("")
+      expect(reek).to receive(:run!) do |args|
+        expect(args).to include('lib/foo.rb', 'lib/bar.rb')
+      end.and_return("")
       reek.emit
     end
   end

--- a/spec/metric_fu/run_spec.rb
+++ b/spec/metric_fu/run_spec.rb
@@ -29,7 +29,7 @@ describe MetricFu do
       # limited set, so we can test the basic functionality
       # without significantly slowing down the specs.
       MetricFu.configuration.configure_metrics do |metric|
-        if metric.name == :reek
+        if metric.name == :cane
           metric.enable
           metric.activated = true
           # so this doesn't seem to always be true


### PR DESCRIPTION
As described in #239: metric_fu hangs when using reek >= 1.6.2.
Reek will now be used as a library preventing this issue.

Tested against reek 1.3.8, 1.6.1, 1.6.3.