### PR TITLE
Fix incorrectly passing --config option to reek

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@ As such, a _Feature_ would map to either major (breaking change) or minor. A _bu
 * Breaking Changes
 * Features
 * Fixes
+  * Fix incorrectly passing --config option to reek. (Martin Gotink, #243, fixes #242)
 * Misc
 
 ### [4.11.2](https://github.com/metricfu/metric_fu/compare/v4.11.1...v4.11.2)

--- a/lib/metric_fu/metrics/reek/generator.rb
+++ b/lib/metric_fu/metrics/reek/generator.rb
@@ -105,7 +105,7 @@ module MetricFu
       [
         disable_line_number_option,
         turn_off_color,
-        config_option,
+        *config_option,
         *files
       ].reject(&:empty?)
     end
@@ -114,9 +114,9 @@ module MetricFu
     def config_option
       config_file_pattern =  options[:config_file_pattern]
       if config_file_pattern.to_s.empty?
-        ''
+        ['']
       else
-        "--config #{config_file_pattern}"
+        ['--config', config_file_pattern]
       end
     end
 

--- a/spec/metric_fu/metrics/reek/generator_spec.rb
+++ b/spec/metric_fu/metrics/reek/generator_spec.rb
@@ -14,7 +14,7 @@ describe MetricFu::ReekGenerator do
     it "includes config file pattern into reek parameters when specified" do
       options.merge!({:config_file_pattern => 'lib/config/*.reek' })
       expect(reek).to receive(:run!) do |args|
-        expect(args).to include('--config lib/config/*.reek')
+        expect(args).to include('--config', 'lib/config/*.reek')
       end.and_return('')
       reek.emit
     end


### PR DESCRIPTION
The --config option and associated file name were passed to reek as 1 string while they should be 2 separate items in the arguments array.
Introduced in #240.
Closes #242.