### PR TITLE
Hash hotspots output filenames

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@ As such, a _Feature_ would map to either major (breaking change) or minor. A _bu
 * Breaking Changes
 * Features
 * Fixes
+  * Hash hotspots output filenames. (Martin Gotink, #247, fixes #246)
 * Misc
 
 ### [4.11.3](https://github.com/metricfu/metric_fu/compare/v4.11.2...v4.11.3)

--- a/lib/metric_fu/metrics/hotspots/report.html.erb
+++ b/lib/metric_fu/metrics/hotspots/report.html.erb
@@ -36,7 +36,7 @@
             </b>
             <% unless per_file_data[file].empty? %>
               <small>&laquo;
-                <b><a href="<%= file.gsub(%r{/}, '_') %>.html<%= (line.nil? ? '' : "#line#{line}") %>">annotate</a></b>
+                <b><a href="<%= html_filename(file) %><%= (line.nil? ? '' : "#line#{line}") %>">annotate</a></b>
                &raquo;</small>
             <% end %>
             <br/><br/>

--- a/lib/metric_fu/templates/metrics_template.rb
+++ b/lib/metric_fu/templates/metrics_template.rb
@@ -24,7 +24,7 @@ module MetricFu
     end
 
     def html_filename(file)
-      file = Digest::SHA1.hexdigest(file)
+      file = Digest::SHA1.hexdigest(file)[0..29]
       "#{file.gsub(%r{/}, '_')}.html"
     end
 

--- a/lib/metric_fu/templates/metrics_template.rb
+++ b/lib/metric_fu/templates/metrics_template.rb
@@ -23,6 +23,11 @@ module MetricFu
       write_file_data
     end
 
+    def html_filename(file)
+      file = Digest::SHA1.hexdigest(file)
+      "#{file.gsub(%r{/}, '_')}.html"
+    end
+
     private
 
     def copy_javascripts
@@ -66,10 +71,6 @@ module MetricFu
 
         formatter.write_template(report, html_filename(file))
       end
-    end
-
-    def html_filename(file)
-      "#{file.gsub(%r{/}, '_')}.html"
     end
 
     def template_directory

--- a/spec/metric_fu/templates/metrics_template_spec.rb
+++ b/spec/metric_fu/templates/metrics_template_spec.rb
@@ -6,7 +6,7 @@ describe MetricFu::Templates::MetricsTemplate do
 
   describe "#html_filename" do
     it "returns the hashed filename ending with .html" do
-      expect(template.html_filename("some_file.rb")).to eq("10580a1fcbe74a931db8210462a584791545ab06.html")
+      expect(template.html_filename("some_file.rb")).to eq("10580a1fcbe74a931db8210462a584.html")
     end
   end
 

--- a/spec/metric_fu/templates/metrics_template_spec.rb
+++ b/spec/metric_fu/templates/metrics_template_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+describe MetricFu::Templates::MetricsTemplate do
+
+  let(:template) { Templates::MetricsTemplate.new }
+
+  describe "#html_filename" do
+    it "returns the hashed filename ending with .html" do
+      expect(template.html_filename("some_file.rb")).to eq("10580a1fcbe74a931db8210462a584791545ab06.html")
+    end
+  end
+
+end


### PR DESCRIPTION
This prevents 'File name too long @ rb_sysopen - long_file_name.rb.html (Errno::ENAMETOOLONG)' exception when hotspots it trying to save its output.
Closes #246.