### PR TITLE
File link fixes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@ As such, a _Feature_ would map to either major (breaking change) or minor. A _bu
 * Fixes
   * Hash hotspots output filenames. (Martin Gotink, #247, fixes #246)
   * Fix invalid file links for rails best practices (Martin Gotink, #248)
+  * Add file links to cane report (Martin Gotink, #248)
 * Misc
 
 ### [4.11.3](https://github.com/metricfu/metric_fu/compare/v4.11.2...v4.11.3)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,7 +11,7 @@ As such, a _Feature_ would map to either major (breaking change) or minor. A _bu
 * Fixes
   * Hash hotspots output filenames. (Martin Gotink, #247, fixes #246)
   * Fix invalid file links for rails best practices (Martin Gotink, #248)
-  * Add file links to cane report (Martin Gotink, #248)
+  * Add file links to cane and saikuro reports (Martin Gotink, #248)
 * Misc
 
 ### [4.11.3](https://github.com/metricfu/metric_fu/compare/v4.11.2...v4.11.3)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@ As such, a _Feature_ would map to either major (breaking change) or minor. A _bu
 * Features
 * Fixes
   * Hash hotspots output filenames. (Martin Gotink, #247, fixes #246)
+  * Fix invalid file links for rails best practices (Martin Gotink, #248)
 * Misc
 
 ### [4.11.3](https://github.com/metricfu/metric_fu/compare/v4.11.2...v4.11.3)

--- a/lib/metric_fu/metrics/cane/report.html.erb
+++ b/lib/metric_fu/metrics/cane/report.html.erb
@@ -15,7 +15,7 @@
   <% count = 0 %>
   <% @cane[:violations][:abc_complexity].each do |violation| %>
     <tr class='<%= cycle("light", "dark", count) %>'>
-      <td><%=violation[:file]%></td>
+      <td><%=link_to_filename(violation[:file])%></td>
       <td><%=violation[:method]%></td>
       <td><%=violation[:complexity]%></td>
     </tr>
@@ -33,7 +33,7 @@
   <% count = 0 %>
   <% @cane[:violations][:line_style].each do |violation| %>
     <tr class='<%= cycle("light", "dark", count) %>'>
-      <td><%=violation[:line]%></td>
+      <td><%=link_to_filename(*violation[:line].split(':'))%></td>
       <td><%=violation[:description]%></td>
     </tr>
     <% count += 1 %>
@@ -63,7 +63,7 @@
   <% count = 0 %>
   <% @cane[:violations][:comment].each do |violation| %>
     <tr class='<%= cycle("light", "dark", count) %>'>
-      <td><%=violation[:line]%></td>
+      <td><%=link_to_filename(*violation[:line].split(':'))%></td>
       <td><%=violation[:class_name]%></td>
     </tr>
     <% count += 1 %>

--- a/lib/metric_fu/metrics/saikuro/report.html.erb
+++ b/lib/metric_fu/metrics/saikuro/report.html.erb
@@ -40,7 +40,7 @@
 <% @saikuro[:files].each do |file| %>
   <% file[:classes].each do |klass| %>
       <% if !klass[:methods].empty? %>
-        <h3><%= file[:filename] %></h3>
+        <h3><%=link_to_filename(file[:filename])%></h3>
         <h4>Class : <%= klass[:class_name] %></h4>
         <h5>Total complexity : <%= klass[:complexity] %></h5>
         <h5>Total lines : <%= klass[:lines] %></h5>

--- a/lib/metric_fu/templates/template.rb
+++ b/lib/metric_fu/templates/template.rb
@@ -188,11 +188,7 @@ module MetricFu
     end
 
     def complete_file_path(filename)
-      File.expand_path(remove_leading_slash(filename))
-    end
-
-    def remove_leading_slash(filename)
-      filename.gsub(/^\//, '')
+      File.expand_path(filename)
     end
 
     def render_as_txmt_protocol? # :nodoc:

--- a/spec/metric_fu/templates/template_spec.rb
+++ b/spec/metric_fu/templates/template_spec.rb
@@ -175,6 +175,23 @@ describe MetricFu::Template do
         expect(result).to eq("<a href='http://example.org/files/filename'>filename</a>")
       end
     end
+
+    context "given an absolute path" do
+      it "returns a link with that absolute path" do
+        name = "/some/file.rb"
+        result = @template.send(:link_to_filename, name)
+        expect(result).to eq("<a href='file:///some/file.rb'>/some/file.rb</a>")
+      end
+    end
+
+    context "given a relative path" do
+      it "returns a link with the absolute path" do
+        name = "./some/file.rb"
+        expected = File.expand_path(name)
+        result = @template.send(:link_to_filename, name)
+        expect(result).to eq("<a href='file://#{expected}'>./some/file.rb</a>")
+      end
+    end
   end
 
   describe "#cycle" do


### PR DESCRIPTION
 - Fix invalid file links for rails best practices
 - Add file links to cane report
 - Add file links to saikuro report

I hope removing Template#remove_leading_slash doesn't have any side effects, it was added in 296048fb but I don't see a reason why, no metrics seem to be reporting this way (anymore). All file links in the reports seem to be working fine after removing it.