### PR TITLE
Fix incorrectly displaying not covered lines

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@ As such, a _Feature_ would map to either major (breaking change) or minor. A _bu
   * Hash hotspots output filenames. (Martin Gotink, #247, fixes #246)
   * Fix invalid file links for rails best practices (Martin Gotink, #248)
   * Add file links to cane and saikuro reports (Martin Gotink, #248)
+  * Fix incorrectly displaying not covered lines. (Martin Gotink, #249)
 * Misc
 
 ### [4.11.3](https://github.com/metricfu/metric_fu/compare/v4.11.2...v4.11.3)

--- a/lib/metric_fu/metrics/rcov/generator.rb
+++ b/lib/metric_fu/metrics/rcov/generator.rb
@@ -2,6 +2,7 @@ MetricFu.lib_require { 'utility' }
 MetricFu.lib_require { 'calculate' }
 MetricFu.data_structures_require { 'line_numbers' }
 require_relative 'rcov_format_coverage'
+require_relative 'rcov_line'
 require_relative 'external_client'
 
 module MetricFu

--- a/lib/metric_fu/metrics/rcov/rcov_format_coverage.rb
+++ b/lib/metric_fu/metrics/rcov/rcov_format_coverage.rb
@@ -7,41 +7,6 @@ module MetricFu
       @rcov_text = rcov_text
     end
 
-    class Line
-      attr_accessor :content, :was_run
-
-      def initialize(content, was_run)
-        @content = content
-        @was_run = was_run
-      end
-
-      def to_h
-        {:content => @content, :was_run => @was_run}
-      end
-
-      def covered?
-        @was_run.one?
-      end
-      def missed?
-        @was_run.zero?
-      end
-      def ignored?
-        @was_run.nil?
-      end
-      def self.line_coverage(lines)
-        lines.map{|line| line[:was_run] }
-      end
-      def self.covered_lines(line_coverage)
-        line_coverage.count(1)
-      end
-      def self.missed_lines(line_coverage)
-        line_coverage.count(0)
-      end
-      def self.ignored_lines(line_coverage)
-        line_coverage.count(nil)
-      end
-    end
-
     def to_h
       rcov_text = @rcov_text.split(NEW_FILE_MARKER)
 
@@ -68,7 +33,7 @@ module MetricFu
                          else
                            1
                          end
-          Line.new(raw_line[3..-1], covered_line).to_h
+          RCovLine.new(raw_line[3..-1], covered_line).to_h
         end
         content.reject! {|line| line[:content].to_s == '' }
         files[fname] = {:lines => content}
@@ -101,9 +66,9 @@ module MetricFu
       end
 
       def self.percent_run(lines)
-        line_coverage = Line.line_coverage(lines)
-        covered_lines = Line.covered_lines(line_coverage)
-        ignored_lines = Line.ignored_lines(line_coverage)
+        line_coverage = RCovLine.line_coverage(lines)
+        covered_lines = RCovLine.covered_lines(line_coverage)
+        ignored_lines = RCovLine.ignored_lines(line_coverage)
         relevant_lines = lines.count - ignored_lines
         if block_given?
           yield covered_lines, relevant_lines

--- a/lib/metric_fu/metrics/rcov/rcov_line.rb
+++ b/lib/metric_fu/metrics/rcov/rcov_line.rb
@@ -1,0 +1,48 @@
+module MetricFu
+  class RCovLine
+    attr_accessor :content, :was_run
+
+    def initialize(content, was_run)
+      @content = content
+      @was_run = was_run
+    end
+
+    def to_h
+      {:content => @content, :was_run => @was_run}
+    end
+
+    def covered?
+      @was_run == 1
+    end
+
+    def missed?
+      @was_run == 0
+    end
+
+    def ignored?
+      @was_run.nil?
+    end
+
+    def self.line_coverage(lines)
+      lines.map{|line| line[:was_run] }
+    end
+
+    def self.covered_lines(line_coverage)
+      line_coverage.count(1)
+    end
+
+    def self.missed_lines(line_coverage)
+      line_coverage.count(0)
+    end
+
+    def self.ignored_lines(line_coverage)
+      line_coverage.count(nil)
+    end
+
+    def css_class
+      return '' if ignored?
+
+      missed? ? 'rcov_not_run' : 'rcov_run'
+    end
+  end
+end

--- a/lib/metric_fu/metrics/rcov/report.html.erb
+++ b/lib/metric_fu/metrics/rcov/report.html.erb
@@ -29,8 +29,8 @@
     <table class="rcov_code">
     <% file[:lines].each_with_index do |line, index| %>
       <tr>
-        <% css_class = line[:was_run] == 0 ? "rcov_not_run" : "rcov_run" %>
-        <td class="<%= css_class %>"><%= link_to_filename(fname, index + 1, "<pre>#{line[:content]}</pre>") %></td>
+        <% rcov_line = RCovLine.new(line[:content], line[:was_run]) %>
+        <td class="<%= rcov_line.css_class %>"><%= link_to_filename(fname, index + 1, "<pre>#{line[:content]}</pre>") %></td>
       </tr>
     <% end %>
     </table>

--- a/lib/metric_fu/metrics/rcov/report.html.erb
+++ b/lib/metric_fu/metrics/rcov/report.html.erb
@@ -29,7 +29,7 @@
     <table class="rcov_code">
     <% file[:lines].each_with_index do |line, index| %>
       <tr>
-        <% css_class = line[:was_run] ? "rcov_run" : "rcov_not_run" %>
+        <% css_class = line[:was_run] == 0 ? "rcov_not_run" : "rcov_run" %>
         <td class="<%= css_class %>"><%= link_to_filename(fname, index + 1, "<pre>#{line[:content]}</pre>") %></td>
       </tr>
     <% end %>

--- a/spec/metric_fu/metrics/rcov/rcov_line_spec.rb
+++ b/spec/metric_fu/metrics/rcov/rcov_line_spec.rb
@@ -1,0 +1,89 @@
+require "spec_helper"
+require 'metric_fu/metrics/rcov/rcov_line'
+
+describe MetricFu::RCovLine do
+  describe "#to_h" do
+    it "returns a hash with the content and was_run" do
+      rcov_line = RCovLine.new('some content', 1)
+
+      expect(rcov_line.to_h).to eq({content: 'some content', was_run: 1})
+    end
+  end
+
+  describe "#covered?" do
+    it "returns true if was_run is 1" do
+      rcov_line = RCovLine.new('', 1)
+
+      expect(rcov_line.covered?).to eq(true)
+    end
+
+    it "returns false if was_run is 0" do
+      rcov_line = RCovLine.new('', 0)
+
+      expect(rcov_line.covered?).to eq(false)
+    end
+
+    it "returns false if was_run is nil" do
+      rcov_line = RCovLine.new('', nil)
+
+      expect(rcov_line.covered?).to eq(false)
+    end
+  end
+
+  describe "#missed?" do
+    it "returns true if was_run is 0" do
+      rcov_line = RCovLine.new('', 0)
+
+      expect(rcov_line.missed?).to eq(true)
+    end
+
+    it "returns false if was_run is 1" do
+      rcov_line = RCovLine.new('', 1)
+
+      expect(rcov_line.missed?).to eq(false)
+    end
+
+    it "returns false if was_run is nil" do
+      rcov_line = RCovLine.new('', nil)
+
+      expect(rcov_line.missed?).to eq(false)
+    end
+  end
+
+  describe "#ignored?" do
+    it "returns true if was_run is nil" do
+      rcov_line = RCovLine.new('', nil)
+
+      expect(rcov_line.ignored?).to eq(true)
+    end
+
+    it "returns false if was_run is 1" do
+      rcov_line = RCovLine.new('', 1)
+
+      expect(rcov_line.ignored?).to eq(false)
+    end
+
+    it "returns false if was_run is 0" do
+      rcov_line = RCovLine.new('', 0)
+
+      expect(rcov_line.ignored?).to eq(false)
+    end
+  end
+
+  describe "#css_class" do
+    it "returns '' for an ignored line" do
+      rcov_line = RCovLine.new('', nil)
+      expect(rcov_line.css_class).to eq('')
+    end
+
+    it "returns 'rcov_not_run' for a missed line" do
+      rcov_line = RCovLine.new('', 0)
+      expect(rcov_line.css_class).to eq('rcov_not_run')
+    end
+
+    it "returns 'rcov_run' for a covered line" do
+      rcov_line = RCovLine.new('', 1)
+      expect(rcov_line.css_class).to eq('rcov_run')
+    end
+  end
+end


### PR DESCRIPTION
The rcov report is outputting ignored lines (nil) as not covered, while not covered lines (0) are outputted as covered. This is due to a check if the coverage for a line is falsey, while 0 is truthy in ruby.