### PR TITLE
Ruby 2.2 support

### DIFF
--- a/spec/support/suite.rb
+++ b/spec/support/suite.rb
@@ -8,7 +8,7 @@ def scratch_directory(name)
 end
 
 def artifact_test_dir
-  @artficat_test_dir ||= File.join(MetricFu::APP_ROOT, 'tmp','metric_fu','test')
+  File.join(MetricFu::APP_ROOT, 'tmp','metric_fu','test')
 end
 
 # Let's shift the output directories so that we don't interfere with


### PR DESCRIPTION
Ruby 2.2 is throwing a 'can't modify frozen NilClass' error on spec/support/suite.rb:11:in `artifact_test_dir'.
In artifact_test_dir an instance variable is being set on the current object, but at the end of the test suite this seems be be an empty (nil) context. In ruby 2.2 the nil object is frozen, so no instance variables can't be added to it anymore.
Removing the instance variable assignment fixes this, it's only caching one in two requests anyway.