### PR TITLE
Style ignored lines the same as covered lines

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@ As such, a _Feature_ would map to either major (breaking change) or minor. A _bu
 * Breaking Changes
 * Features
 * Fixes
+  * Use same styling for covered as ignored lines. (Martin Gotink, #254)
 * Misc
 
 ### [4.11.4](https://github.com/metricfu/metric_fu/compare/v4.11.3...v4.11.4)

--- a/lib/metric_fu/metrics/rcov/rcov_line.rb
+++ b/lib/metric_fu/metrics/rcov/rcov_line.rb
@@ -40,9 +40,9 @@ module MetricFu
     end
 
     def css_class
-      return "" if ignored?
+      return "rcov_not_run" if missed?
 
-      missed? ? "rcov_not_run" : "rcov_run"
+      "rcov_run"
     end
   end
 end

--- a/spec/metric_fu/metrics/rcov/rcov_line_spec.rb
+++ b/spec/metric_fu/metrics/rcov/rcov_line_spec.rb
@@ -71,9 +71,9 @@ describe MetricFu::RCovLine do
   end
 
   describe "#css_class" do
-    it "returns '' for an ignored line" do
+    it "returns 'rcov_run' for an ignored line" do
       rcov_line = RCovLine.new("", nil)
-      expect(rcov_line.css_class).to eq("")
+      expect(rcov_line.css_class).to eq("rcov_run")
     end
 
     it "returns 'rcov_not_run' for a missed line" do


### PR DESCRIPTION
Ignored lines are showing up in a red font with a hover which makes it almost impossible to read.