### PR TITLE
Dir.exists? is a deprecated name, use Dir.exist? instead

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@ As such, a _Feature_ would map to either major (breaking change) or minor. A _bu
 * Features
 * Fixes
 * Misc
+  * Fix deprecation warnings for Dir.exists? (Jared Szechy, #269)
 
 ### [4.12.0](https://github.com/metricfu/metric_fu/compare/v4.11.4...v4.12.0)
 

--- a/lib/metric_fu/io.rb
+++ b/lib/metric_fu/io.rb
@@ -59,7 +59,7 @@ module MetricFu
 
       # Add the 'app' directory if we're running within rails.
       def set_code_dirs
-        @directories["code_dirs"] = %w(app lib).select { |dir| Dir.exists?(dir) }
+        @directories["code_dirs"] = %w(app lib).select { |dir| Dir.exist?(dir) }
       end
     end
 


### PR DESCRIPTION
Resolves warning on load

`/Users/jared/.rvm/gems/jruby-9.0.0.0/gems/metric_fu-4.12.0/lib/metric_fu/io.rb:62: warning: Dir.exists? is a deprecated name, use Dir.exist? instead`