### PR TITLE
Resolves #273

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@ As such, a _Feature_ would map to either major (breaking change) or minor. A _bu
 * Breaking Changes
 * Features
 * Fixes
+  * Making it works with flog 4.4.0. (Américo Duarte, #274, fixes #273)
 * Misc
   * Fix deprecation warnings for Dir.exists? (Jared Szechy, #269)
 

--- a/lib/metric_fu/metrics/flog/generator.rb
+++ b/lib/metric_fu/metrics/flog/generator.rb
@@ -1,5 +1,6 @@
 require "pathname"
 require "optparse"
+require "path_expander"
 
 module MetricFu
   class FlogGenerator < Generator
@@ -12,8 +13,10 @@ module MetricFu
         "--all",
         options[:continue] ? "--continue" : nil,
       ].compact
+      expander = PathExpander.new(options[:dirs_to_flog], "**/*.{rb,rake}")
+      files = expander.process
       @flogger = FlogCLI.new parse_options
-      @flogger.flog *options[:dirs_to_flog]
+      @flogger.flog *files
     end
 
     def analyze

--- a/metric_fu.gemspec
+++ b/metric_fu.gemspec
@@ -53,6 +53,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "code_metrics",          ["~> 0.1"]
 
   # other dependencies
+  # path expansion used to passing dirs to flog
+  s.add_runtime_dependency "path_expander", "~> 1.0"
   # ruby version identification
   s.add_runtime_dependency "redcard"
   # syntax highlighting

--- a/spec/metric_fu/generator_spec.rb
+++ b/spec/metric_fu/generator_spec.rb
@@ -44,17 +44,17 @@ describe MetricFu::Generator do
   describe "#generate_result" do
     it "should  raise an error when calling #emit" do
       @abstract_class = MetricFu::Generator.new
-      expect { @abstract_class.generate_result }.to raise_error
+      expect { @abstract_class.generate_result }.to raise_error(RuntimeError, /must be implemented/)
     end
 
     it "should call #analyze" do
       @abstract_class = MetricFu::Generator.new
-      expect { @abstract_class.generate_result }.to raise_error
+      expect { @abstract_class.generate_result }.to raise_error(RuntimeError, /must be implemented/)
     end
 
     it "should call #to_h" do
       @abstract_class = MetricFu::Generator.new
-      expect { @abstract_class.generate_result }.to raise_error
+      expect { @abstract_class.generate_result }.to raise_error(RuntimeError, /must be implemented/)
     end
   end
 

--- a/spec/metric_fu/metrics/flog/generator_spec.rb
+++ b/spec/metric_fu/metrics/flog/generator_spec.rb
@@ -14,7 +14,10 @@ describe MetricFu::FlogGenerator do
     it "should look for files and flog them" do
       expect(FlogCLI).to receive(:parse_options).with(["--all", "--continue"]).and_return("options")
       expect(FlogCLI).to receive(:new).with("options").and_return(flogger = double("flogger"))
-      expect(flogger).to receive(:flog).with("lib")
+
+      files = PathExpander.new(["lib"], "**/*.{rb,rake}").process
+      expect(flogger).to receive(:flog).with(*files)
+
       @flog.emit
     end
   end


### PR DESCRIPTION
The API of flog gem was changed here: seattlerb/flog@858d125

Using expander like it was suggested in documentation above the method changed
does not breaks the compatibility with older versions of flog gem.
