### PR TITLE
Fixed broken dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ tmp
 *.swp
 tags
 .idea
+
+# rvm
+.ruby-version
+.ruby-gemset

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,36 @@
 # encoding: utf-8
 source "https://rubygems.org"
 
-if RUBY_VERSION == "1.9.2"
+if RUBY_VERSION =~ /^2\.2\.[0-1]p?\d*/ || RUBY_VERSION =~ /^2\.1\.\d*p?\d*/
+  gem "activesupport", "~> 4.2"
+  gem "json", "~> 1.7"
+  gem "rubocop", platforms: :mri, groups: [:test, :local_development]
+elsif RUBY_VERSION =~ /^2\.0\..*/
+  gem "activesupport", "~> 4.2"
+  gem "json", "~> 1.7"
+  gem "unparser", "0.2.4"
+  gem "rubocop", platforms: :mri, groups: [:test, :local_development]
+elsif RUBY_VERSION =~ /^1\.9\.3.*/
+  gem "activesupport", "~> 4.2"
+  gem "json", "~> 1.7"
+  gem "unparser", "0.2.4"
+  gem "json_pure", "2.0.1"
+  gem "mime-types", "2.99.3"
+  gem "rest-client", "1.8.0"
+  gem "rubocop", platforms: :mri, groups: [:test, :local_development]
+elsif RUBY_VERSION =~ /^1\.9\.2.*/
   # because of https://github.com/railsbp/rails_best_practices/blob/master/rails_best_practices.gemspec
   gem "activesupport", "~> 3.2"
   # because of https://github.com/troessner/reek/issues/334
   gem "reek", "~> 1.4.0"
   # rbp -> as -> i18n
-  gem 'i18n', '0.6.11'
+  gem "i18n", "0.6.11"
   gem "parallel", "= 1.3.3" # 1.3.4 disallows 1.9.2
-else
-  gem "rubocop", platforms: :mri, groups: [:test, :local_development]
+  gem "unparser", "0.1.5"
+  gem "json_pure", "2.0.1"
+  gem "mime-types", "2.99.3"
+  gem "rest-client", "1.8.0"
+  gem "json", "~> 1.7"
 end
 
 gemspec path: File.expand_path("..", __FILE__)


### PR DESCRIPTION
Got the build to pass in Travis by including specific gems with specific versions of Ruby.  For older  versions of Ruby, a lot of these gems simply dropped support.

Also, don't know how to fix VersionEye issues.  If a gem simply does not have a license, I have no idea how to figure out what it is or should be.

- Standardized to double quotes
- Fixed unparser version
- Fixed json_pure, mime-types and rest-client deps
- Fixed dep for concord, ruby 192
- Added ruby version checks
- Added rvm files to ignore