### PR TITLE
Fix test warnings

### DIFF
--- a/lib/metric_fu/generator.rb
+++ b/lib/metric_fu/generator.rb
@@ -124,7 +124,7 @@ module MetricFu
     end
 
     def self.not_implemented
-      raise <<-EOF
+      raise NotImplementedError.new <<-EOF
         Required method #{caller[0]} not implemented in #{__FILE__}.
         This method must be implemented by a concrete class descending
         from Generator.  See generator class documentation for more

--- a/spec/metric_fu/generator_spec.rb
+++ b/spec/metric_fu/generator_spec.rb
@@ -42,19 +42,19 @@ describe MetricFu::Generator do
   end
 
   describe "#generate_result" do
-    it "should  raise an error when calling #emit" do
+    it "should raise an error when calling #emit" do
       @abstract_class = MetricFu::Generator.new
-      expect { @abstract_class.generate_result }.to raise_error
+      expect { @abstract_class.generate_result }.to raise_error NotImplementedError
     end
 
     it "should call #analyze" do
       @abstract_class = MetricFu::Generator.new
-      expect { @abstract_class.generate_result }.to raise_error
+      expect { @abstract_class.generate_result }.to raise_error NotImplementedError
     end
 
     it "should call #to_h" do
       @abstract_class = MetricFu::Generator.new
-      expect { @abstract_class.generate_result }.to raise_error
+      expect { @abstract_class.generate_result }.to raise_error NotImplementedError
     end
   end
 


### PR DESCRIPTION
Addresses https://github.com/metricfu/metric_fu/issues/288.

The original error thrown was a RuntimeError and it seemed appropriate given the name of the method that a NotImplementedError should be thrown here instead.

Also, as per issue 288, we need to add the correct expectation to match the error thrown to eliminate the warnings you see when running the tests.