### PR TITLE
Updated jruby-openssl and removed unused rb-notifu gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gemspec path: File.expand_path("..", __FILE__)
 
 platform :jruby do
   group :jruby do
-    gem "jruby-openssl", "~> 0.8.5"
+    gem "jruby-openssl", "~> 0.9.17"
   end
 end
 
@@ -65,6 +65,5 @@ group :guard do
 
   # notification handling
   gem "libnotify",               "~> 0.8.0", require: false
-  gem "rb-notifu",               "~> 0.0.4", require: false
   gem "terminal-notifier-guard", "~> 1.5.3", require: false
 end


### PR DESCRIPTION
Addresses https://github.com/metricfu/metric_fu/issues/281.

1. Updated jruby-openssl to latest version that has license file.
2.  Removed rb-notifu gem.  It hasn't been touched in 6 years (https://github.com/stereobooster/rb-notifu) and I couldn't find a reference to it anywhere in this project.