### PR TITLE
changelog for v4.12.0..master

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,14 +4,7 @@ Each change should fall into categories that would affect whether the release is
 
 As such, a _Feature_ would map to either major (breaking change) or minor. A _bug fix_ to a patch.  And _misc_ is either minor or patch, the difference being kind of fuzzy for the purposes of history.  Adding tests would be patch level.
 
-### Master [changes](https://github.com/metricfu/metric_fu/compare/v4.12.0...master)
-
-* Breaking Changes
-* Features
-* Fixes
-* Misc
-
-### [4.13.0](https://github.com/metricfu/metric_fu/compare/v4.12.0...v4.13.0)
+### Unreleased
 
 * Breaking Changes
 * Features

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,7 +10,24 @@ As such, a _Feature_ would map to either major (breaking change) or minor. A _bu
 * Features
 * Fixes
 * Misc
+
+### [4.13.0](https://github.com/metricfu/metric_fu/compare/v4.12.0...v4.13.0)
+
+* Breaking Changes
+* Features
+  * Setup CI pipeline on AppVeyor and fixed specs. (Rasmus Bergholdt, #285, fixes #284)
+  * Upgraded roodi to v5.0.0 (Jonathan Keam, #287)
+  * Updated jruby-openssl and removed unused rb-notifu gem (Jonathan Keam, #290)
+* Fixes
+  * Rails best practices options (Noah S-W, #264, #263)
   * Fix deprecation warnings for Dir.exists? (Jared Szechy, #269)
+  * Fix specs (Luciano Sousa, #270)
+  * Fixed broken dependencies (Jonathan Keam, #279)
+  * FlogCli.flog must receive an expanded list of files (Rasmus Bergholdt, #282, fixes #273)
+  * Fix test warnings (Jonathan Keam, #289, addresses #288)
+* Misc
+  * Add a Gitter chat badge to README.md (#259)
+
 
 ### [4.12.0](https://github.com/metricfu/metric_fu/compare/v4.11.4...v4.12.0)
 


### PR DESCRIPTION
@bf4 on #292 you were asking for help with the changelog. Here's a summary of v4.12.0..master. There is a link to a comparison in the changelog that references v4.13.0 which is what I presume is next, but perhaps you consider these changes smaller. I did not change the VERSION.