### PR TITLE
Cannot run metric_fu because gem dependency regex fails

### DIFF
--- a/lib/metric_fu/gem_version.rb
+++ b/lib/metric_fu/gem_version.rb
@@ -12,7 +12,7 @@ module MetricFu
     REQUIREMENT_LIST = /(?<qr1>["'])(?<req1>#{REQUIREMENT})\k<qr1>(?:[ \t]*,[ \t]*(?<qr2>["'])(?<req2>#{REQUIREMENT})\k<qr2>)?/
     REQUIREMENTS = /(?:#{REQUIREMENT_LIST}|\[[ \t]*#{REQUIREMENT_LIST}[ \t]*\])/
     COMMENT = /(#[^\n]*)?/
-    ADD_DEPENDENCY_CALL = /^[ \t]*\w+\.add(?<type>_runtime|_development)?_dependency\(?[ \t]*#{QUOTED_GEM_NAME}(?:[ \t]*,[ \t]*#{REQUIREMENTS})?[ \t]*\)?[ \t]*#{COMMENT}$/
+    ADD_DEPENDENCY_CALL = /^[ \t]*\w+\.add(?<type>_runtime|_development)?_dependency\(?[ \t]*#{QUOTED_GEM_NAME}(.freeze)?(?:[ \t]*,[ \t]*#{REQUIREMENTS})?[ \t]*\)?[ \t]*#{COMMENT}$/
 
     def initialize
       @gem_spec = File.open(gemspec, "rb") { |f| f.readlines }


### PR DESCRIPTION
I get an error if I try to run metric_fu on my rails project:

```
$ bundle exec metric_fu
******* STARTING METRIC cane
bundler: failed to load command: metric_fu (/Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bin/metric_fu)
NoMethodError: undefined method `[]' for nil:NilClass
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/gem_version.rb:35:in `block in gem_runtime_dependencies'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/gem_version.rb:32:in `map'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/gem_version.rb:32:in `gem_runtime_dependencies'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/gem_version.rb:44:in `for'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/gem_version.rb:57:in `for'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/gem_run.rb:13:in `block in initialize'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/gem_run.rb:13:in `fetch'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/gem_run.rb:13:in `initialize'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/metric.rb:51:in `new'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/metric.rb:51:in `run_external'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/generator.rb:90:in `run!'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/metrics/cane/generator.rb:17:in `emit'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/generator.rb:104:in `generate_result'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/reporting/result.rb:48:in `add'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/run.rb:21:in `block in measure'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/run.rb:19:in `each'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/run.rb:19:in `measure'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/run.rb:9:in `run'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/cli/helper.rb:19:in `run'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/lib/metric_fu/cli/client.rb:19:in `run'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bundler/gems/metric_fu-e26307966ac7/bin/metric_fu:9:in `<top (required)>'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bin/metric_fu:22:in `load'
  /Users/phylor/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/bin/metric_fu:22:in `<top (required)>'
```

The problem is that the `ADD_DEPENDENCY_CALL` regex fails. If I debug, the failing line is the following:

    s.add_runtime_dependency(%q<flay>.freeze, [">= 2.0.1", "~> 2.1"])

It seems that there is a `.freeze` included which is not supported in the regex.