### PR TITLE
Remove reek config_file_pattern option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,15 @@ before_install:
   - gem install bundler
   - bundle config --local without local_development yard guard
 rvm:
-  # 2.1, not 2.1.0 until fixed https://github.com/travis-ci/travis-ci/issues/2220
+  - 2.5
+  - 2.4
+  - 2.3
   - 2.2
   - 2.1
   - 2.0.0
   - 1.9.2
   - 1.9.3
-  - jruby
+  - jruby-9.1.9.0
   - "rbx-2"
 matrix:
   allow_failures:

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # encoding: utf-8
 source "https://rubygems.org"
 
-if RUBY_VERSION =~ /^2\.2\.[0-1]p?\d*/ || RUBY_VERSION =~ /^2\.1\.\d*p?\d*/ || RUBY_VERSION =~ /^2.3.\d*p?\d*/
+if RUBY_VERSION =~ /^2.[3-5].\d*p?\d*/ || RUBY_VERSION =~ /^2\.2\.[0-1]p?\d*/ || RUBY_VERSION =~ /^2\.1\.\d*p?\d*/
   gem "activesupport", "~> 4.2"
   gem "json", "~> 1.7"
   gem "rubocop", platforms: :mri, groups: [:test, :local_development]

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # encoding: utf-8
 source "https://rubygems.org"
 
-if RUBY_VERSION =~ /^2\.2\.[0-1]p?\d*/ || RUBY_VERSION =~ /^2\.1\.\d*p?\d*/ || RUBY_VERSION =~ /^2.3.\d*p?\d*/
+if RUBY_VERSION =~ /^2\.2\.[0-1]p?\d*/ || RUBY_VERSION =~ /^2\.1\.\d*p?\d*/
   gem "activesupport", "~> 4.2"
   gem "json", "~> 1.7"
   gem "rubocop", platforms: :mri, groups: [:test, :local_development]

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # encoding: utf-8
 source "https://rubygems.org"
 
-if RUBY_VERSION =~ /^2.[3-5].\d*p?\d*/ || RUBY_VERSION =~ /^2\.2\.[0-1]p?\d*/ || RUBY_VERSION =~ /^2\.1\.\d*p?\d*/
+if RUBY_VERSION =~ /^2\.2\.[0-1]p?\d*/ || RUBY_VERSION =~ /^2\.1\.\d*p?\d*/ || RUBY_VERSION =~ /^2.3.\d*p?\d*/
   gem "activesupport", "~> 4.2"
   gem "json", "~> 1.7"
   gem "rubocop", platforms: :mri, groups: [:test, :local_development]

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # encoding: utf-8
 source "https://rubygems.org"
 
-if RUBY_VERSION =~ /^2\.2\.[0-1]p?\d*/ || RUBY_VERSION =~ /^2\.1\.\d*p?\d*/
+if RUBY_VERSION =~ /^2\.2\.[0-1]p?\d*/ || RUBY_VERSION =~ /^2\.1\.\d*p?\d*/ || RUBY_VERSION =~ /^2.3.\d*p?\d*/
   gem "activesupport", "~> 4.2"
   gem "json", "~> 1.7"
   gem "rubocop", platforms: :mri, groups: [:test, :local_development]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,12 @@ skip_tags: true
 
 environment:
   matrix:
+    - RUBY_VERSION: 25
+    - RUBY_VERSION: 25-x64
+    - RUBY_VERSION: 24
+    - RUBY_VERSION: 24-x64
+    - RUBY_VERSION: 23
+    - RUBY_VERSION: 23-x64
     - RUBY_VERSION: 22
     - RUBY_VERSION: 22-x64
     - RUBY_VERSION: 21

--- a/lib/metric_fu/environment.rb
+++ b/lib/metric_fu/environment.rb
@@ -121,6 +121,10 @@ module MetricFu
       @osx ||= platform.include?("darwin")
     end
 
+    def windows?
+      (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ platform) != nil
+    end
+
     def ruby_strangely_makes_accessors_private?
       @private_accessors ||= ruby192? || jruby?
     end

--- a/lib/metric_fu/metrics/reek/generator.rb
+++ b/lib/metric_fu/metrics/reek/generator.rb
@@ -8,14 +8,14 @@ module MetricFu
       files = files_to_analyze
       if files.empty?
         mf_log "Skipping Reek, no files found to analyze"
-        @output = run!([], config_files)
+        @output = run!([])
       else
-        @output = run!(files, config_files)
+        @output = run!(files)
       end
     end
 
-    def run!(files, config_files)
-      examiner.new(files, config_files)
+    def run!(files)
+      examiner.new(files)
     end
 
     def analyze
@@ -55,11 +55,6 @@ module MetricFu
       dirs_to_reek = options[:dirs_to_reek]
       files_to_reek = dirs_to_reek.map { |dir| Dir[File.join(dir, "**", "*.rb")] }.flatten
       remove_excluded_files(files_to_reek)
-    end
-
-    # TODO: Check that specified line config file exists
-    def config_files
-      Array(options[:config_file_pattern])
     end
 
     def analyze_smells(smells)

--- a/lib/metric_fu/metrics/reek/metric.rb
+++ b/lib/metric_fu/metrics/reek/metric.rb
@@ -6,8 +6,7 @@ module MetricFu
 
     def default_run_options
       {
-        dirs_to_reek: MetricFu::Io::FileSystem.directory("code_dirs"),
-        config_file_pattern: nil,
+        dirs_to_reek: MetricFu::Io::FileSystem.directory("code_dirs")
       }
     end
 

--- a/metric_fu.gemspec
+++ b/metric_fu.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "flay",                  [">= 2.0.1",  "~> 2.1"]
   s.add_runtime_dependency "churn",                 [">= 0.0.35"]
   s.add_runtime_dependency "flog",                  [">= 4.1.1",  "~> 4.1"]
-  s.add_runtime_dependency "reek",                  [">= 1.3.4",  "< 3.0"]
+  s.add_runtime_dependency "reek",                  [">= 1.3.4",  "< 5.0"]
   s.add_runtime_dependency "cane",                  [">= 2.5.2",  "~> 2.5"]
   s.add_runtime_dependency "rails_best_practices",  [">= 1.14.3", "~> 1.14"]
   s.add_runtime_dependency "metric_fu-Saikuro",     [">= 1.1.3",  "~> 1.1"]

--- a/metric_fu.gemspec
+++ b/metric_fu.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "flay",                  [">= 2.0.1",  "~> 2.1"]
   s.add_runtime_dependency "churn",                 [">= 0.0.35"]
   s.add_runtime_dependency "flog",                  [">= 4.1.1",  "~> 4.1"]
-  s.add_runtime_dependency "reek",                  [">= 1.3.4",  "< 5.0"]
+  s.add_runtime_dependency "reek",                  [">= 1.3.4",  "< 3.0"]
   s.add_runtime_dependency "cane",                  [">= 2.5.2",  "~> 2.5"]
   s.add_runtime_dependency "rails_best_practices",  [">= 1.14.3", "~> 1.14"]
   s.add_runtime_dependency "metric_fu-Saikuro",     [">= 1.1.3",  "~> 1.1"]

--- a/metric_fu.gemspec
+++ b/metric_fu.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
 
   # metric dependencies
   s.add_runtime_dependency "flay",                  [">= 2.0.1",  "~> 2.1"]
-  s.add_runtime_dependency "churn",                 ["~> 0.0.35"]
+  s.add_runtime_dependency "churn",                 [">= 0.0.35"]
   s.add_runtime_dependency "flog",                  [">= 4.1.1",  "~> 4.1"]
   s.add_runtime_dependency "reek",                  [">= 1.3.4",  "< 3.0"]
   s.add_runtime_dependency "cane",                  [">= 2.5.2",  "~> 2.5"]

--- a/spec/metric_fu/metrics/reek/configuration_spec.rb
+++ b/spec/metric_fu/metrics/reek/configuration_spec.rb
@@ -6,7 +6,7 @@ describe MetricFu::Configuration, "for reek" do
     it "should set @reek to {:dirs_to_reek => @code_dirs}" do
       load_metric "reek"
       expect(MetricFu::Metric.get_metric(:reek).run_options).to eq(
-              config_file_pattern: nil, dirs_to_reek: ["lib"]
+              dirs_to_reek: ["lib"]
       )
     end
   end

--- a/spec/metric_fu/metrics/reek/generator_spec.rb
+++ b/spec/metric_fu/metrics/reek/generator_spec.rb
@@ -11,26 +11,8 @@ describe MetricFu::ReekGenerator do
       allow(reek).to receive(:files_to_analyze).and_return(files_to_analyze)
     end
 
-    it "includes config file pattern into reek parameters when specified" do
-      options.merge!(config_file_pattern: "lib/config/*.reek")
-
-      expect(reek).to receive(:run!) do |_files, config_files|
-        expect(config_files).to eq(["lib/config/*.reek"])
-      end.and_return("")
-
-      reek.emit
-    end
-
-    it "passes an empty array when no config file pattern is specified" do
-      expect(reek).to receive(:run!) do |_files, config_files|
-        expect(config_files).to eq([])
-      end.and_return("")
-
-      reek.emit
-    end
-
     it "includes files to analyze into reek parameters" do
-      expect(reek).to receive(:run!) do |files, _config_files|
+      expect(reek).to receive(:run!) do |files|
         expect(files).to eq(["lib/foo.rb", "lib/bar.rb"])
       end.and_return("")
 

--- a/spec/usage_test_spec.rb
+++ b/spec/usage_test_spec.rb
@@ -65,7 +65,7 @@ README
     specify "fails when the command runs with an error" do
       code = "sandwhich_fu ruby"
       test_result = SnippetRunner.new(code, "sh").run_code
-      expect(test_result.captured_output).to match(failed_command_error)
+      expect(test_result.captured_output).to start_with(failed_command_error)
       expect(test_result.success).to eq(false)
     end
     specify "succeeds when the code exits with a zero exit status" do
@@ -83,7 +83,7 @@ README
   end
 
   def failed_command_error
-    defined?(JRUBY_VERSION) ? "IOError" : "Errno::ENOENT"
+    "Errno::ENOENT"
   end
 
   def fixtures_path

--- a/spec/usage_test_spec.rb
+++ b/spec/usage_test_spec.rb
@@ -63,7 +63,7 @@ README
       expect(test_result.success).to eq(true)
     end
     specify "fails when the command runs with an error" do
-      code = "sandwhich_fu ruby"
+      code = "sandwhich_fu ruby;"
       test_result = SnippetRunner.new(code, "sh").run_code
       expect(test_result.captured_output).to start_with(failed_command_error)
       expect(test_result.success).to eq(false)
@@ -83,7 +83,7 @@ README
   end
 
   def failed_command_error
-    "Errno::ENOENT"
+    MetricFu.configuration.windows? ? 'Errno::ENOENT' : "SystemCommandError"
   end
 
   def fixtures_path


### PR DESCRIPTION
I couldn't install ruby 2.2.x on my laptop, so I necessarily had to add a newer ruby to the Gemfile in order to work on this pull request. Rspec tests continued to pass in 2.3.x, 2.4.x, and 2.5.x. I'd be happy to revert that change in this pull request and submit it separately.

The reek config loading changed drastically. Providing a config.reek file in the current working directory (or any of its parent directories, or your home directory) will be detected by reek. The former API that allowed metric_fu to explicitly specify the config file location is gone. I propose we adopt reek's new conventional config file finding method and abandon the explicit config_file_pattern option.

for consideration on issue #262 