### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,10 @@ before_install:
   - bundle config --local without local_development yard guard
 rvm:
   # 2.1, not 2.1.0 until fixed https://github.com/travis-ci/travis-ci/issues/2220
-  - 2.2
-  - 2.1
-  - 2.0.0
-  - 1.9.2
-  - 1.9.3
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
   - jruby
   - "rbx-2"
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ before_install:
   - bundle config --local without local_development yard guard
 rvm:
   # 2.1, not 2.1.0 until fixed https://github.com/travis-ci/travis-ci/issues/2220
-  - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - jruby
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,9 @@ before_install:
   - bundle config --local without local_development yard guard
 rvm:
   # 2.1, not 2.1.0 until fixed https://github.com/travis-ci/travis-ci/issues/2220
-  - 2.3
   - 2.4
   - 2.5
   - 2.6
   - jruby
-  - "rbx-2"
 matrix:
-  allow_failures:
-    - rvm: rbx-2
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,6 @@ rvm:
   - 2.6
   - jruby
 matrix:
+  allow_failures:
+    - rvm: jruby
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,10 @@ skip_tags: true
 
 environment:
   matrix:
-    - RUBY_VERSION: 22
-    - RUBY_VERSION: 22-x64
-    - RUBY_VERSION: 21
-    - RUBY_VERSION: 21-x64
-    - RUBY_VERSION: 200
-    - RUBY_VERSION: 193
+    - RUBY_VERSION: 25
+    - RUBY_VERSION: 25-x64
+    - RUBY_VERSION: 26
+    - RUBY_VERSION: 26-x64
 
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,8 @@ environment:
     - RUBY_VERSION: 25-x64
     - RUBY_VERSION: 26
     - RUBY_VERSION: 26-x64
+    - RUBY_VERSION: 27
+    - RUBY_VERSION: 27-x64
 
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%

--- a/metric_fu.gemspec
+++ b/metric_fu.gemspec
@@ -67,5 +67,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "test_construct"
   # ensure we have a JSON parser
   s.add_development_dependency "json"
-  s.add_development_dependency "simplecov", "~> 0.9"
+  s.add_development_dependency "simplecov", "< 0.18"
 end


### PR DESCRIPTION
Hey @bf4, 

This PR brings Travis CI's configuration up to speed. It fixes #307.

I realize that it is actively dropping support for all these rubies: 

- 2.2
- 2.1
- 2.0.0
- 1.9.2		
- 1.9.3
- rbx

But I think it's a good way to unblock PRs failing. 

What do you think?

Thanks!
