### PR TITLE
Remove specific versions for guard dependencies 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,8 +58,8 @@ group :development do
 end
 
 group :guard do
-  gem "guard",         "~> 1.8.1"
-  gem "guard-bundler", "~> 1.0.0"
+  gem "guard"
+  gem "guard-bundler"
   gem "guard-rspec"
 
   # file system change event handling


### PR DESCRIPTION
Hey @bf4, 

This fixes #309. It is a commit extracted from #306, 

Please check it out.

Thanks! 