### PR TITLE
Fix Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,6 @@
 version: '{build}'
+image:
+  - Visual Studio 2019
 
 skip_tags: true
 
@@ -14,6 +16,7 @@ environment:
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
   - gem install bundler
+  - bundle config force_ruby_platform true
   - bundle install --path=vendor/bundle --retry=3 --jobs=3
 
 cache:


### PR DESCRIPTION
Actual test failures where fixed by @etagwerker in https://github.com/metricfu/metric_fu/pull/306

Then we had a [platform specific gem resolution problem](https://github.com/rubygems/bundler/pull/7522) which would not let us bundle successfully. 

This issue is already fixed in bundler side but not yet released so a workaround is to use the `force_ruby_platform` bundler config for now
 https://github.com/rubygems/bundler/pull/7522#issuecomment-571557108


