### PR TITLE
Require digest

### DIFF
--- a/lib/metric_fu/templates/metrics_template.rb
+++ b/lib/metric_fu/templates/metrics_template.rb
@@ -24,6 +24,7 @@ module MetricFu
     end
 
     def html_filename(file)
+      require "digest"
       file = Digest::SHA1.hexdigest(file)[0..29]
       "#{file.gsub(%r{/}, '_')}.html"
     end


### PR DESCRIPTION
Require digest so specs doen't fail on windows  with: 
```
Error: NameError; message uninitialized constant MetricFu::Templates::MetricsTemplate::Digest. 
```