### PR TITLE
Make metric_fu compatible with Ruby 3.0 

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,7 +5,7 @@
 # This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
-name: Ruby
+name: Test
 
 on:
   push:
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0']
 
     steps:
     - uses: actions/checkout@v2

--- a/lib/metric_fu/formatter/html.rb
+++ b/lib/metric_fu/formatter/html.rb
@@ -88,7 +88,8 @@ module MetricFu
       #   The directory path where the 'index.html' we want to open is
       #   stored
       def show_in_browser(dir)
-        uri = URI.join(URI.escape("file://#{dir}/"), "index.html")
+        parser = URI::Parser.new
+        uri = URI.join(parser.escape("file://#{dir}/"), "index.html")
         Launchy.open(uri) if open_in_browser?
       end
     end

--- a/lib/metric_fu/utility.rb
+++ b/lib/metric_fu/utility.rb
@@ -35,8 +35,8 @@ module MetricFu
       FileUtils.rm_rf(*args)
     end
 
-    def mkdir_p(*args)
-      FileUtils.mkdir_p(*args)
+    def mkdir_p(dir, **args)
+      FileUtils.mkdir_p(dir, **args)
     end
 
     def glob(*args)

--- a/spec/metric_fu/formatter/html_spec.rb
+++ b/spec/metric_fu/formatter/html_spec.rb
@@ -80,7 +80,8 @@ describe MetricFu::Formatter::HTML do
       allow(MetricFu.configuration).to receive(:is_cruise_control_rb?).and_return(false)
       formatter = MetricFu::Formatter::HTML.new
       path = MetricFu.run_path.join(directory("output_directory"))
-      uri = URI.join(URI.escape("file://#{path}/"), "index.html")
+      parser = URI::Parser.new
+      uri = URI.join(parser.escape("file://#{path}/"), "index.html")
       expect(Launchy).to receive(:open).with(uri)
       formatter.finish
       formatter.display_results
@@ -125,7 +126,8 @@ describe MetricFu::Formatter::HTML do
       allow(MetricFu.configuration).to receive(:is_cruise_control_rb?).and_return(false)
       formatter = MetricFu::Formatter::HTML.new(output: @output)
       path = MetricFu.run_path.join("#{directory('base_directory')}/#{@output}")
-      uri = URI.join(URI.escape("file://#{path}/"), "index.html")
+      parser = URI::Parser.new
+      uri = URI.join(parser.escape("file://#{path}/"), "index.html")
       expect(Launchy).to receive(:open).with(uri)
       formatter.finish
       formatter.display_results


### PR DESCRIPTION
Hi there,

~~This fixes a part of the #322 issue:~~
This PR fixes #322. 

```
bundle exec rspec spec
"setting timeout 15.0 seconds"
Run options:
  include {:focus=>true}
  exclude {:slow=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 9651
***..................................................................................................................................................................................*................................................................................................................................................................................../Users/etagwerker/Projects/fastruby/metric_fu/spec/metric_fu/formatter/html_spec.rb:128: warning: URI.escape is obsolete
/Users/etagwerker/Projects/fastruby/metric_fu/lib/metric_fu/formatter/html.rb:91: warning: URI.escape is obsolete
........../Users/etagwerker/Projects/fastruby/metric_fu/spec/metric_fu/formatter/html_spec.rb:83: warning: URI.escape is obsolete
/Users/etagwerker/Projects/fastruby/metric_fu/lib/metric_fu/formatter/html.rb:91: warning: URI.escape is obsolete
.........
```

In order to test this you would have to run the test suite with Ruby 2.7.x. and 3.0.x

Found this solution over here: https://stackoverflow.com/a/67618304

Please check it out.

Thanks! 