### PR TITLE
Fixes default Rake task to find spec files 

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,4 +22,4 @@ jobs:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
-      run: bundle exec rspec spec
+      run: bundle exec rake

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ desc "Run all specs in spec directory"
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.verbose = false
 
-  t.pattern = "spec/**/_spec.rb"
+  t.pattern = "spec/**/*_spec.rb"
   # we require spec_helper so we don't get an RSpec warning about
   # examples being defined before configuration.
   t.ruby_opts = "-I./spec -r./spec/capture_warnings -rspec_helper"


### PR DESCRIPTION
Hi there,

`bundle exec rake` was not working as expected, so I decided to fix the regex so that it actually finds the _spec files... 😄 

Also, I updated the GitHub CI configuration to simply run `bundle exec rake`

Please check it out.

Thanks! 

